### PR TITLE
Add CI workflow for lint, test, and build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install
+        working-directory: FleetFlow
+
+      - name: Lint
+        run: npm run lint
+        working-directory: FleetFlow
+
+      - name: Test
+        run: npm test --if-present
+        working-directory: FleetFlow
+
+      - name: Build
+        run: npm run build
+        working-directory: FleetFlow


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to lint, test, and build on pull requests
- expose Supabase credentials via encrypted repository secrets for CI

## Testing
- `npm run lint`
- `npm test --if-present`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689b6496f644832cbf84e83c4c303e45