### PR TITLE
docs: add deployment and release guides

### DIFF
--- a/FleetFlow/.gitignore
+++ b/FleetFlow/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.env
+package-lock.json

--- a/FleetFlow/README.md
+++ b/FleetFlow/README.md
@@ -138,7 +138,9 @@ Open [http://localhost:5173](http://localhost:5173) (or the port Vite shows). Th
 
 ## Deployment
 
-* **Frontend:** Netlify (set `VITE_SUPABASE_URL` & `VITE_SUPABASE_ANON_KEY` in site env). Build: `npm run build`, Publish dir: `dist/`.
+Detailed deployment instructions live in [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md). Versioning and release guidance is in [docs/RELEASE.md](docs/RELEASE.md).
+
+* **Frontend:** Netlify (build: `npm run build`, publish: `dist/`). Set `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` as site environment variables.
 * **Database:** Managed by Supabase; apply schema changes via SQL migrations.
 
 ## Roadmap

--- a/FleetFlow/docs/DEPLOYMENT.md
+++ b/FleetFlow/docs/DEPLOYMENT.md
@@ -1,0 +1,20 @@
+# Deployment Guide
+
+## Netlify hosting
+
+1. Create a new site on [Netlify](https://www.netlify.com/) and link it to this repository.
+2. The repository includes a `netlify.toml` with build settings:
+   - Build command: `npm run build`
+   - Publish directory: `dist`
+   - Node version: `20`
+3. In the Netlify dashboard, configure the following environment variables under **Site settings → Build & deploy → Environment**:
+   - `VITE_SUPABASE_URL`: URL of your production Supabase project.
+   - `VITE_SUPABASE_ANON_KEY`: anon public key for the project.
+4. Trigger a deploy. Netlify will run the build and publish the `dist` directory.
+
+## Production Supabase setup
+
+1. Create a Supabase project and run the schema and seed SQL scripts.
+2. Generate the anon public API key from **Project settings → API**.
+3. Copy the **Project URL** and **anon key** and set them as `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` in Netlify (or your `.env` file for local development).
+4. Apply future database changes using Supabase migrations to keep production in sync.

--- a/FleetFlow/docs/RELEASE.md
+++ b/FleetFlow/docs/RELEASE.md
@@ -1,0 +1,17 @@
+# Release Process
+
+1. Ensure all code is linted and builds successfully.
+2. Update the version using semantic versioning:
+
+   ```bash
+   npm version patch # or minor / major
+   ```
+
+3. Push commits and tags:
+
+   ```bash
+   git push origin main --follow-tags
+   ```
+
+4. Netlify will automatically deploy the tagged commit to production.
+5. Create a GitHub release summarising the changes.

--- a/FleetFlow/netlify.toml
+++ b/FleetFlow/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+  command = "npm run build"
+  publish = "dist"
+
+[build.environment]
+  NODE_VERSION = "20"


### PR DESCRIPTION
## Summary
- add Netlify config for building the frontend
- document production deployment and Supabase environment variables
- describe semantic versioning release process

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `VITE_SUPABASE_URL=https://example.supabase.co VITE_SUPABASE_ANON_KEY=anon npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689b6499ac64832cadd1b09bcd31b8e0