### PR TITLE
chore: ignore env and dependencies

### DIFF
--- a/FleetFlow/.gitignore
+++ b/FleetFlow/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+.env


### PR DESCRIPTION
## Summary
- add `.env` placeholders for Supabase URL and anon key
- ignore environment file and local dependencies

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689b646cdb5c832ca4957d88ef13eb82