### PR TITLE
Add scaffolding for calendar modules

### DIFF
--- a/FleetFlow/src/api/queries.ts
+++ b/FleetFlow/src/api/queries.ts
@@ -1,0 +1,4 @@
+export const fetchExample = async (): Promise<null> => {
+  // TODO: implement query
+  return null
+}

--- a/FleetFlow/src/components/WeekCalendar.tsx
+++ b/FleetFlow/src/components/WeekCalendar.tsx
@@ -1,0 +1,5 @@
+import './week-calendar.css'
+
+export default function WeekCalendar() {
+  return <div className='week-calendar'>Week Calendar</div>
+}

--- a/FleetFlow/src/components/week-calendar.css
+++ b/FleetFlow/src/components/week-calendar.css
@@ -1,0 +1,3 @@
+.week-calendar {
+  display: flex;
+}

--- a/FleetFlow/src/lib/supabase.ts
+++ b/FleetFlow/src/lib/supabase.ts
@@ -1,0 +1,3 @@
+export const supabase = {
+  // TODO: initialize Supabase client
+}

--- a/FleetFlow/src/lib/weeks.ts
+++ b/FleetFlow/src/lib/weeks.ts
@@ -1,0 +1,9 @@
+export const getWeekDays = (date = new Date()): Date[] => {
+  const start = new Date(date)
+  start.setDate(start.getDate() - start.getDay())
+  return Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(start)
+    d.setDate(start.getDate() + i)
+    return d
+  })
+}

--- a/FleetFlow/src/pages/CalendarPage.tsx
+++ b/FleetFlow/src/pages/CalendarPage.tsx
@@ -1,0 +1,10 @@
+import WeekCalendar from '../components/WeekCalendar'
+
+export default function CalendarPage() {
+  return (
+    <div>
+      <h1>Calendar</h1>
+      <WeekCalendar />
+    </div>
+  )
+}

--- a/FleetFlow/src/types.ts
+++ b/FleetFlow/src/types.ts
@@ -1,0 +1,5 @@
+export interface CalendarEvent {
+  id: string
+  date: Date
+  title: string
+}


### PR DESCRIPTION
## Summary
- scaffold placeholder API and lib files
- add minimal WeekCalendar component and calendar page
- define basic types for calendar events

## Testing
- `pre-commit run --files FleetFlow/src/api/queries.ts FleetFlow/src/components/WeekCalendar.tsx FleetFlow/src/components/week-calendar.css FleetFlow/src/lib/supabase.ts FleetFlow/src/lib/weeks.ts FleetFlow/src/pages/CalendarPage.tsx FleetFlow/src/types.ts`

------
https://chatgpt.com/codex/tasks/task_b_689b6a8bb084832c91a23c24d2104fa0