### PR TITLE
feat: add example supabase query

### DIFF
--- a/FleetFlow/package.json
+++ b/FleetFlow/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.55.0",
+    "@tanstack/react-query": "^5.85.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },

--- a/FleetFlow/src/api/queries.ts
+++ b/FleetFlow/src/api/queries.ts
@@ -1,4 +1,20 @@
-export const fetchExample = async (): Promise<null> => {
-  // TODO: implement query
-  return null
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '../lib/supabase'
+import type { Example } from '../types'
+
+export const fetchExample = async (): Promise<Example[]> => {
+  const { data, error } = await supabase.from('examples').select('*')
+  if (error) {
+    throw new Error(error.message)
+  }
+  if (!data) {
+    throw new Error('No data returned')
+  }
+  return data as Example[]
 }
+
+export const useExampleQuery = () =>
+  useQuery<Example[], Error>({
+    queryKey: ['examples'],
+    queryFn: fetchExample,
+  })

--- a/FleetFlow/src/types.ts
+++ b/FleetFlow/src/types.ts
@@ -3,3 +3,8 @@ export interface CalendarEvent {
   date: Date
   title: string
 }
+
+export interface Example {
+  id: number
+  name: string
+}


### PR DESCRIPTION
## Summary
- implement supabase-backed example query with react-query
- define Example interface for typed responses
- add @tanstack/react-query dependency

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689ca8f77878832cb490e931db9d9ecd