### PR TITLE
feat: build week calendar component

### DIFF
--- a/FleetFlow/src/components/WeekCalendar.tsx
+++ b/FleetFlow/src/components/WeekCalendar.tsx
@@ -1,5 +1,47 @@
+import { getWeekDays } from '../lib/weeks'
 import './week-calendar.css'
 
-export default function WeekCalendar() {
-  return <div className='week-calendar'>Week Calendar</div>
+export interface WeekCalendarProps {
+  selectedDate: Date
+  onSelectDate?: (date: Date) => void
+  onPrevWeek?: () => void
+  onNextWeek?: () => void
+}
+
+export default function WeekCalendar({
+  selectedDate,
+  onSelectDate,
+  onPrevWeek,
+  onNextWeek,
+}: WeekCalendarProps) {
+  const days = getWeekDays(selectedDate)
+
+  return (
+    <div className='week-calendar'>
+      <button className='nav-button' onClick={() => onPrevWeek?.()} aria-label='previous week'>
+        ‹
+      </button>
+      <div className='day-labels'>
+        {days.map((day) => {
+          const isSelected = day.toDateString() === selectedDate.toDateString()
+          const label = day.toLocaleDateString(undefined, {
+            weekday: 'short',
+            day: 'numeric',
+          })
+          return (
+            <button
+              key={day.toISOString()}
+              className={`day-label${isSelected ? ' selected' : ''}`}
+              onClick={() => onSelectDate?.(day)}
+            >
+              {label}
+            </button>
+          )
+        })}
+      </div>
+      <button className='nav-button' onClick={() => onNextWeek?.()} aria-label='next week'>
+        ›
+      </button>
+    </div>
+  )
 }

--- a/FleetFlow/src/components/week-calendar.css
+++ b/FleetFlow/src/components/week-calendar.css
@@ -1,3 +1,30 @@
 .week-calendar {
   display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.week-calendar .day-labels {
+  display: flex;
+  flex: 1;
+  justify-content: space-between;
+  gap: 0.25rem;
+}
+
+.week-calendar .day-label {
+  padding: 0.25rem 0.5rem;
+  text-align: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.week-calendar .day-label.selected {
+  font-weight: 600;
+}
+
+.week-calendar .nav-button {
+  background: none;
+  border: none;
+  cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- use getWeekDays to render a week calendar
- add navigation callbacks and date selection
- style week calendar with basic layout

## Testing
- `npm --prefix FleetFlow run lint`
- `npm --prefix FleetFlow test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_689caaad6b64832ca95402c7b4018a47