### PR TITLE
Load events in calendar page

### DIFF
--- a/FleetFlow/src/api/queries.ts
+++ b/FleetFlow/src/api/queries.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../lib/supabase'
-import type { Example } from '../types'
+import type { CalendarEvent, Example } from '../types'
 
 export const fetchExample = async (): Promise<Example[]> => {
   const { data, error } = await supabase.from('examples').select('*')
@@ -17,4 +17,18 @@ export const useExampleQuery = () =>
   useQuery<Example[], Error>({
     queryKey: ['examples'],
     queryFn: fetchExample,
+  })
+
+export const fetchEvents = async (): Promise<CalendarEvent[]> => {
+  const { data, error } = await supabase.from('calendar_events').select('*')
+  if (error) {
+    throw new Error(error.message)
+  }
+  return (data ?? []).map((e) => ({ ...e, date: new Date(e.date) })) as CalendarEvent[]
+}
+
+export const useEventsQuery = () =>
+  useQuery<CalendarEvent[], Error>({
+    queryKey: ['events'],
+    queryFn: fetchEvents,
   })

--- a/FleetFlow/src/components/WeekCalendar.tsx
+++ b/FleetFlow/src/components/WeekCalendar.tsx
@@ -1,8 +1,10 @@
 import { getWeekDays } from '../lib/weeks'
+import type { CalendarEvent } from '../types'
 import './week-calendar.css'
 
 export interface WeekCalendarProps {
   selectedDate: Date
+  events?: CalendarEvent[]
   onSelectDate?: (date: Date) => void
   onPrevWeek?: () => void
   onNextWeek?: () => void
@@ -10,6 +12,7 @@ export interface WeekCalendarProps {
 
 export default function WeekCalendar({
   selectedDate,
+  events,
   onSelectDate,
   onPrevWeek,
   onNextWeek,
@@ -28,14 +31,25 @@ export default function WeekCalendar({
             weekday: 'short',
             day: 'numeric',
           })
+          const dayEvents =
+            events?.filter((e) => {
+              const date = e.date instanceof Date ? e.date : new Date(e.date)
+              return date.toDateString() === day.toDateString()
+            }) ?? []
           return (
-            <button
-              key={day.toISOString()}
-              className={`day-label${isSelected ? ' selected' : ''}`}
-              onClick={() => onSelectDate?.(day)}
-            >
-              {label}
-            </button>
+            <div key={day.toISOString()} className='day-column'>
+              <button
+                className={`day-label${isSelected ? ' selected' : ''}`}
+                onClick={() => onSelectDate?.(day)}
+              >
+                {label}
+              </button>
+              {dayEvents.map((ev) => (
+                <div key={ev.id} className='event'>
+                  {ev.title}
+                </div>
+              ))}
+            </div>
           )
         })}
       </div>

--- a/FleetFlow/src/components/week-calendar.css
+++ b/FleetFlow/src/components/week-calendar.css
@@ -11,6 +11,16 @@
   gap: 0.25rem;
 }
 
+.week-calendar .day-column {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.week-calendar .event {
+  font-size: 0.75rem;
+}
+
 .week-calendar .day-label {
   padding: 0.25rem 0.5rem;
   text-align: center;

--- a/FleetFlow/src/pages/CalendarPage.tsx
+++ b/FleetFlow/src/pages/CalendarPage.tsx
@@ -1,10 +1,34 @@
+import { useState } from 'react'
 import WeekCalendar from '../components/WeekCalendar'
+import { useEventsQuery } from '../api/queries'
 
 export default function CalendarPage() {
+  const [selectedDate, setSelectedDate] = useState(new Date())
+  const { data: events, isLoading, error } = useEventsQuery()
+
+  if (isLoading) {
+    return <div>Loading events...</div>
+  }
+
+  if (error) {
+    return <div>Error: {error.message}</div>
+  }
+
+  const handlePrevWeek = () =>
+    setSelectedDate(new Date(selectedDate.getTime() - 7 * 24 * 60 * 60 * 1000))
+  const handleNextWeek = () =>
+    setSelectedDate(new Date(selectedDate.getTime() + 7 * 24 * 60 * 60 * 1000))
+
   return (
     <div>
       <h1>Calendar</h1>
-      <WeekCalendar />
+      <WeekCalendar
+        selectedDate={selectedDate}
+        events={events ?? []}
+        onSelectDate={setSelectedDate}
+        onPrevWeek={handlePrevWeek}
+        onNextWeek={handleNextWeek}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- query Supabase for calendar events and expose via `useEventsQuery`
- load events on calendar page with loading and error states
- display events in week calendar view

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689cae51cb5c832cbe64f698594bc58d