### PR TITLE
Add equipment scheduling models with runtime validation

### DIFF
--- a/FleetFlow/package.json
+++ b/FleetFlow/package.json
@@ -13,7 +13,8 @@
     "@supabase/supabase-js": "^2.55.0",
     "@tanstack/react-query": "^5.85.0",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "zod": "^4.0.17"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/FleetFlow/src/api/queries.ts
+++ b/FleetFlow/src/api/queries.ts
@@ -1,16 +1,24 @@
 import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../lib/supabase'
-import type { CalendarEvent, Example } from '../types'
+import {
+  ExampleSchema,
+  CalendarEventSchema,
+  EquipmentGroupSchema,
+  AllocationSchema,
+  RequestSchema,
+  type Example,
+  type CalendarEvent,
+  type EquipmentGroup,
+  type Allocation,
+  type Request,
+} from '../types'
 
 export const fetchExample = async (): Promise<Example[]> => {
   const { data, error } = await supabase.from('examples').select('*')
   if (error) {
     throw new Error(error.message)
   }
-  if (!data) {
-    throw new Error('No data returned')
-  }
-  return data as Example[]
+  return ExampleSchema.array().parse(data ?? [])
 }
 
 export const useExampleQuery = () =>
@@ -24,11 +32,53 @@ export const fetchEvents = async (): Promise<CalendarEvent[]> => {
   if (error) {
     throw new Error(error.message)
   }
-  return (data ?? []).map((e) => ({ ...e, date: new Date(e.date) })) as CalendarEvent[]
+  return CalendarEventSchema.array().parse(data ?? [])
 }
 
 export const useEventsQuery = () =>
   useQuery<CalendarEvent[], Error>({
     queryKey: ['events'],
     queryFn: fetchEvents,
+  })
+
+export const fetchEquipmentGroups = async (): Promise<EquipmentGroup[]> => {
+  const { data, error } = await supabase.from('equipment_groups').select('*')
+  if (error) {
+    throw new Error(error.message)
+  }
+  return EquipmentGroupSchema.array().parse(data ?? [])
+}
+
+export const useEquipmentGroupsQuery = () =>
+  useQuery<EquipmentGroup[], Error>({
+    queryKey: ['equipment-groups'],
+    queryFn: fetchEquipmentGroups,
+  })
+
+export const fetchAllocations = async (): Promise<Allocation[]> => {
+  const { data, error } = await supabase.from('allocations').select('*')
+  if (error) {
+    throw new Error(error.message)
+  }
+  return AllocationSchema.array().parse(data ?? [])
+}
+
+export const useAllocationsQuery = () =>
+  useQuery<Allocation[], Error>({
+    queryKey: ['allocations'],
+    queryFn: fetchAllocations,
+  })
+
+export const fetchRequests = async (): Promise<Request[]> => {
+  const { data, error } = await supabase.from('hire_requests').select('*')
+  if (error) {
+    throw new Error(error.message)
+  }
+  return RequestSchema.array().parse(data ?? [])
+}
+
+export const useRequestsQuery = () =>
+  useQuery<Request[], Error>({
+    queryKey: ['requests'],
+    queryFn: fetchRequests,
   })

--- a/FleetFlow/src/pages/CalendarPage.tsx
+++ b/FleetFlow/src/pages/CalendarPage.tsx
@@ -1,10 +1,18 @@
 import { useState } from 'react'
 import WeekCalendar from '../components/WeekCalendar'
-import { useEventsQuery } from '../api/queries'
+import {
+  useEventsQuery,
+  useEquipmentGroupsQuery,
+  useAllocationsQuery,
+  useRequestsQuery,
+} from '../api/queries'
 
 export default function CalendarPage() {
   const [selectedDate, setSelectedDate] = useState(new Date())
   const { data: events, isLoading, error } = useEventsQuery()
+  const { data: groups } = useEquipmentGroupsQuery()
+  const { data: allocations } = useAllocationsQuery()
+  const { data: requests } = useRequestsQuery()
 
   if (isLoading) {
     return <div>Loading events...</div>
@@ -22,6 +30,16 @@ export default function CalendarPage() {
   return (
     <div>
       <h1>Calendar</h1>
+      <section>
+        <h2>Equipment Groups</h2>
+        <ul>
+          {groups?.map((g) => (
+            <li key={g.id}>{g.name}</li>
+          ))}
+        </ul>
+        <div>Requests: {requests?.length ?? 0}</div>
+        <div>Allocations: {allocations?.length ?? 0}</div>
+      </section>
       <WeekCalendar
         selectedDate={selectedDate}
         events={events ?? []}

--- a/FleetFlow/src/types.ts
+++ b/FleetFlow/src/types.ts
@@ -1,10 +1,44 @@
-export interface CalendarEvent {
-  id: string
-  date: Date
-  title: string
-}
+import { z } from 'zod'
 
-export interface Example {
-  id: number
-  name: string
-}
+export const ExampleSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+})
+export type Example = z.infer<typeof ExampleSchema>
+
+export const CalendarEventSchema = z.object({
+  id: z.string(),
+  date: z.coerce.date(),
+  title: z.string(),
+})
+export type CalendarEvent = z.infer<typeof CalendarEventSchema>
+
+export const EquipmentGroupSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+})
+export type EquipmentGroup = z.infer<typeof EquipmentGroupSchema>
+
+export const AllocationSchema = z.object({
+  id: z.string(),
+  asset_code: z.string(),
+  group_id: z.string(),
+  start_date: z.coerce.date(),
+  end_date: z.coerce.date(),
+  source: z.string().optional(),
+  contract_status: z.string().optional(),
+  contract_code: z.string().optional(),
+  request_id: z.string().nullable().optional(),
+})
+export type Allocation = z.infer<typeof AllocationSchema>
+
+export const RequestSchema = z.object({
+  id: z.string(),
+  contract_id: z.string(),
+  group_id: z.string(),
+  start_date: z.coerce.date(),
+  end_date: z.coerce.date(),
+  quantity: z.number(),
+  operated: z.boolean(),
+})
+export type Request = z.infer<typeof RequestSchema>


### PR DESCRIPTION
## Summary
- add interfaces & Zod schemas for equipment groups, allocations and requests
- add Supabase queries and hooks using the new schemas
- display groups, allocation and request counts in calendar page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689cb3bb6e74832ca538b9dea1bcc8b2