### PR TITLE
Set up routing with react-router-dom

### DIFF
--- a/FleetFlow/package.json
+++ b/FleetFlow/package.json
@@ -14,6 +14,7 @@
     "@tanstack/react-query": "^5.85.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-router-dom": "^7.8.0",
     "zod": "^4.0.17"
   },
   "devDependencies": {

--- a/FleetFlow/src/App.tsx
+++ b/FleetFlow/src/App.tsx
@@ -1,35 +1,12 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import CalendarPage from './pages/CalendarPage'
 
-function App() {
-  const [count, setCount] = useState(0)
-
+export default function App() {
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<CalendarPage />} />
+      </Routes>
+    </BrowserRouter>
   )
 }
-
-export default App


### PR DESCRIPTION
## Summary
- install `react-router-dom`
- render `CalendarPage` at root route via `BrowserRouter`
- remove Vite starter content

## Testing
- `pre-commit run --files FleetFlow/src/App.tsx FleetFlow/package.json FleetFlow/package-lock.json`
- `npm --prefix FleetFlow test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_689cb84f9adc832c9acc1086d95b0e32