### PR TITLE
Add weekly group utilization view and display

### DIFF
--- a/FleetFlow/package.json
+++ b/FleetFlow/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.55.0",
     "@tanstack/react-query": "^5.85.0",
+    "@tanstack/react-query-devtools": "^5.85.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "zod": "^4.0.17"

--- a/FleetFlow/src/api/queries.ts
+++ b/FleetFlow/src/api/queries.ts
@@ -6,11 +6,13 @@ import {
   EquipmentGroupSchema,
   AllocationSchema,
   RequestSchema,
+  WeeklyGroupUtilizationSchema,
   type Example,
   type CalendarEvent,
   type EquipmentGroup,
   type Allocation,
   type Request,
+  type WeeklyGroupUtilization,
 } from '../types'
 
 export const fetchExample = async (): Promise<Example[]> => {
@@ -81,4 +83,20 @@ export const useRequestsQuery = () =>
   useQuery<Request[], Error>({
     queryKey: ['requests'],
     queryFn: fetchRequests,
+  })
+
+export const fetchWeeklyGroupUtilization = async (): Promise<WeeklyGroupUtilization[]> => {
+  const { data, error } = await supabase
+    .from('vw_weekly_group_utilization')
+    .select('*')
+  if (error) {
+    throw new Error(error.message)
+  }
+  return WeeklyGroupUtilizationSchema.array().parse(data ?? [])
+}
+
+export const useWeeklyGroupUtilizationQuery = () =>
+  useQuery<WeeklyGroupUtilization[], Error>({
+    queryKey: ['weekly-group-utilization'],
+    queryFn: fetchWeeklyGroupUtilization,
   })

--- a/FleetFlow/src/components/WeekCalendar.tsx
+++ b/FleetFlow/src/components/WeekCalendar.tsx
@@ -1,10 +1,16 @@
 import { getWeekDays } from '../lib/weeks'
-import type { CalendarEvent } from '../types'
+import type {
+  CalendarEvent,
+  EquipmentGroup,
+  WeeklyGroupUtilization,
+} from '../types'
 import './week-calendar.css'
 
 export interface WeekCalendarProps {
   selectedDate: Date
   events?: CalendarEvent[]
+  utilization?: WeeklyGroupUtilization[]
+  groups?: EquipmentGroup[]
   onSelectDate?: (date: Date) => void
   onPrevWeek?: () => void
   onNextWeek?: () => void
@@ -13,49 +19,88 @@ export interface WeekCalendarProps {
 export default function WeekCalendar({
   selectedDate,
   events,
+  utilization,
+  groups,
   onSelectDate,
   onPrevWeek,
   onNextWeek,
 }: WeekCalendarProps) {
   const days = getWeekDays(selectedDate)
+  const weekStart = days[0]
 
   return (
-    <div className='week-calendar'>
-      <button className='nav-button' onClick={() => onPrevWeek?.()} aria-label='previous week'>
-        ‹
-      </button>
-      <div className='day-labels'>
-        {days.map((day) => {
-          const isSelected = day.toDateString() === selectedDate.toDateString()
-          const label = day.toLocaleDateString(undefined, {
-            weekday: 'short',
-            day: 'numeric',
-          })
-          const dayEvents =
-            events?.filter((e) => {
-              const date = e.date instanceof Date ? e.date : new Date(e.date)
-              return date.toDateString() === day.toDateString()
-            }) ?? []
-          return (
-            <div key={day.toISOString()} className='day-column'>
-              <button
-                className={`day-label${isSelected ? ' selected' : ''}`}
-                onClick={() => onSelectDate?.(day)}
-              >
-                {label}
-              </button>
-              {dayEvents.map((ev) => (
-                <div key={ev.id} className='event'>
-                  {ev.title}
-                </div>
-              ))}
-            </div>
-          )
-        })}
+    <div>
+      <div className='week-calendar'>
+        <button
+          className='nav-button'
+          onClick={() => onPrevWeek?.()}
+          aria-label='previous week'
+        >
+          ‹
+        </button>
+        <div className='day-labels'>
+          {days.map((day) => {
+            const isSelected = day.toDateString() === selectedDate.toDateString()
+            const label = day.toLocaleDateString(undefined, {
+              weekday: 'short',
+              day: 'numeric',
+            })
+            const dayEvents =
+              events?.filter((e) => {
+                const date = e.date instanceof Date ? e.date : new Date(e.date)
+                return date.toDateString() === day.toDateString()
+              }) ?? []
+            return (
+              <div key={day.toISOString()} className='day-column'>
+                <button
+                  className={`day-label${isSelected ? ' selected' : ''}`}
+                  onClick={() => onSelectDate?.(day)}
+                >
+                  {label}
+                </button>
+                {dayEvents.map((ev) => (
+                  <div key={ev.id} className='event'>
+                    {ev.title}
+                  </div>
+                ))}
+              </div>
+            )
+          })}
+        </div>
+        <button
+          className='nav-button'
+          onClick={() => onNextWeek?.()}
+          aria-label='next week'
+        >
+          ›
+        </button>
       </div>
-      <button className='nav-button' onClick={() => onNextWeek?.()} aria-label='next week'>
-        ›
-      </button>
+      {groups && groups.length > 0 && (
+        <table className='utilization-table'>
+          <thead>
+            <tr>
+              <th>Group</th>
+              <th>On hire</th>
+            </tr>
+          </thead>
+          <tbody>
+            {groups.map((g) => {
+              const util = utilization?.find(
+                (u) =>
+                  u.group_id === g.id &&
+                  new Date(u.week_start).toDateString() ===
+                    weekStart.toDateString()
+              )
+              return (
+                <tr key={g.id}>
+                  <td>{g.name}</td>
+                  <td>{util?.on_hire_count ?? 0}</td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      )}
     </div>
   )
 }

--- a/FleetFlow/src/components/week-calendar.css
+++ b/FleetFlow/src/components/week-calendar.css
@@ -38,3 +38,16 @@
   border: none;
   cursor: pointer;
 }
+
+.utilization-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 0.5rem;
+}
+
+.utilization-table th,
+.utilization-table td {
+  border: 1px solid #ccc;
+  padding: 0.25rem;
+  text-align: center;
+}

--- a/FleetFlow/src/pages/CalendarPage.tsx
+++ b/FleetFlow/src/pages/CalendarPage.tsx
@@ -5,6 +5,7 @@ import {
   useEquipmentGroupsQuery,
   useAllocationsQuery,
   useRequestsQuery,
+  useWeeklyGroupUtilizationQuery,
 } from '../api/queries'
 
 export default function CalendarPage() {
@@ -13,6 +14,7 @@ export default function CalendarPage() {
   const { data: groups } = useEquipmentGroupsQuery()
   const { data: allocations } = useAllocationsQuery()
   const { data: requests } = useRequestsQuery()
+  const { data: utilization } = useWeeklyGroupUtilizationQuery()
 
   if (isLoading) {
     return <div>Loading events...</div>
@@ -43,6 +45,8 @@ export default function CalendarPage() {
       <WeekCalendar
         selectedDate={selectedDate}
         events={events ?? []}
+        utilization={utilization ?? []}
+        groups={groups ?? []}
         onSelectDate={setSelectedDate}
         onPrevWeek={handlePrevWeek}
         onNextWeek={handleNextWeek}

--- a/FleetFlow/src/types.ts
+++ b/FleetFlow/src/types.ts
@@ -42,3 +42,10 @@ export const RequestSchema = z.object({
   operated: z.boolean(),
 })
 export type Request = z.infer<typeof RequestSchema>
+
+export const WeeklyGroupUtilizationSchema = z.object({
+  week_start: z.coerce.date(),
+  group_id: z.string(),
+  on_hire_count: z.number(),
+})
+export type WeeklyGroupUtilization = z.infer<typeof WeeklyGroupUtilizationSchema>


### PR DESCRIPTION
## Summary
- add WeeklyGroupUtilization schema and Supabase query helpers
- show weekly utilization counts per equipment group in WeekCalendar
- wire CalendarPage to query and supply utilization data

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689cb9a464a4832c9dcf7d6ead462939