### PR TITLE
Add Plant Coordinator page with asset allocation

### DIFF
--- a/FleetFlow/src/App.tsx
+++ b/FleetFlow/src/App.tsx
@@ -1,11 +1,13 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import CalendarPage from './pages/CalendarPage'
+import PlantCoordinatorPage from './pages/PlantCoordinatorPage'
 
 export default function App() {
   return (
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<CalendarPage />} />
+        <Route path="/plant-coordinator" element={<PlantCoordinatorPage />} />
       </Routes>
     </BrowserRouter>
   )

--- a/FleetFlow/src/pages/PlantCoordinatorPage.tsx
+++ b/FleetFlow/src/pages/PlantCoordinatorPage.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useRequestsQuery } from '../api/queries'
+import { supabase } from '../lib/supabase'
+
+export default function PlantCoordinatorPage() {
+  const { data: requests, isLoading, error } = useRequestsQuery()
+  const queryClient = useQueryClient()
+  const [activeId, setActiveId] = useState<string | null>(null)
+
+  const allocationMutation = useMutation({
+    mutationFn: async (requestId: string) => {
+      const { error } = await supabase.rpc('rpc_allocate_best_asset', {
+        request_id: requestId,
+      })
+      if (error) {
+        throw new Error(error.message)
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['requests'] })
+      queryClient.invalidateQueries({ queryKey: ['allocations'] })
+    },
+  })
+
+  const handleAllocate = (id: string) => {
+    setActiveId(id)
+    allocationMutation.mutate(id)
+  }
+
+  if (isLoading) {
+    return <div>Loading requests...</div>
+  }
+
+  if (error) {
+    return <div>Error: {error.message}</div>
+  }
+
+  return (
+    <div>
+      <h1>Plant Coordinator</h1>
+      <ul>
+        {requests?.map((r) => (
+          <li key={r.id}>
+            <div>
+              <strong>Contract {r.contract_id}</strong> – Group {r.group_id} – {r.start_date.toLocaleDateString()} to {r.end_date.toLocaleDateString()} – Qty {r.quantity}
+            </div>
+            <button
+              onClick={() => handleAllocate(r.id)}
+              disabled={allocationMutation.isPending && activeId === r.id}
+            >
+              {allocationMutation.isPending && activeId === r.id ? 'Allocating...' : 'Allocate Asset'}
+            </button>
+            {allocationMutation.isError && activeId === r.id && (
+              <div>Error allocating asset</div>
+            )}
+            {allocationMutation.isSuccess && activeId === r.id && (
+              <div>Asset allocated successfully!</div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create plant coordinator page to list hire requests and allocate assets via Supabase RPC
- add routing for the new plant coordinator page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689cba121f00832c94fe8ed7b23584af