### PR TITLE
feat: enhance plant coordinator panel

### DIFF
--- a/FleetFlow/src/api/queries.ts
+++ b/FleetFlow/src/api/queries.ts
@@ -7,12 +7,14 @@ import {
   AllocationSchema,
   RequestSchema,
   WeeklyGroupUtilizationSchema,
+  AssetScoreSchema,
   type Example,
   type CalendarEvent,
   type EquipmentGroup,
   type Allocation,
   type Request,
   type WeeklyGroupUtilization,
+  type AssetScore,
 } from '../types'
 
 export const fetchExample = async (): Promise<Example[]> => {
@@ -84,6 +86,16 @@ export const useRequestsQuery = () =>
     queryKey: ['requests'],
     queryFn: fetchRequests,
   })
+
+export const scoreAssets = async (requestId: string): Promise<AssetScore[]> => {
+  const { data, error } = await supabase.rpc('rpc_score_assets', {
+    request_id: requestId,
+  })
+  if (error) {
+    throw new Error(error.message)
+  }
+  return AssetScoreSchema.array().parse(data ?? [])
+}
 
 export const fetchWeeklyGroupUtilization = async (): Promise<WeeklyGroupUtilization[]> => {
   const { data, error } = await supabase

--- a/FleetFlow/src/pages/PlantCoordinatorPage.tsx
+++ b/FleetFlow/src/pages/PlantCoordinatorPage.tsx
@@ -1,12 +1,25 @@
 import { useState } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { useRequestsQuery } from '../api/queries'
+import {
+  useRequestsQuery,
+  useAllocationsQuery,
+  scoreAssets,
+} from '../api/queries'
+import type { Request, AssetScore } from '../types'
 import { supabase } from '../lib/supabase'
 
 export default function PlantCoordinatorPage() {
   const { data: requests, isLoading, error } = useRequestsQuery()
+  const { data: allocations } = useAllocationsQuery()
   const queryClient = useQueryClient()
   const [activeId, setActiveId] = useState<string | null>(null)
+  const [scoringId, setScoringId] = useState<string | null>(null)
+  const [scores, setScores] = useState<Record<string, AssetScore[]>>({})
+
+  const openRequests = requests?.filter((r) => {
+    const count = allocations?.filter((a) => a.request_id === r.id).length ?? 0
+    return count < r.quantity
+  })
 
   const allocationMutation = useMutation({
     mutationFn: async (requestId: string) => {
@@ -14,8 +27,18 @@ export default function PlantCoordinatorPage() {
         request_id: requestId,
       })
       if (error) {
+        if (error.message === 'NO_INTERNAL_ASSET_AVAILABLE') {
+          const { error: hireError } = await supabase
+            .from('external_hires')
+            .insert({ request_id: requestId })
+          if (hireError) {
+            throw new Error(hireError.message)
+          }
+          return { external: true }
+        }
         throw new Error(error.message)
       }
+      return { external: false }
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['requests'] })
@@ -23,9 +46,21 @@ export default function PlantCoordinatorPage() {
     },
   })
 
+  const scoreMutation = useMutation({
+    mutationFn: async (request: Request) => scoreAssets(request.id),
+    onSuccess: (data, variables) => {
+      setScores((prev) => ({ ...prev, [variables.id]: data }))
+    },
+  })
+
   const handleAllocate = (id: string) => {
     setActiveId(id)
     allocationMutation.mutate(id)
+  }
+
+  const handleScore = (request: Request) => {
+    setScoringId(request.id)
+    scoreMutation.mutate(request)
   }
 
   if (isLoading) {
@@ -40,26 +75,47 @@ export default function PlantCoordinatorPage() {
     <div>
       <h1>Plant Coordinator</h1>
       <ul>
-        {requests?.map((r) => (
+        {openRequests?.map((r) => (
           <li key={r.id}>
             <div>
               <strong>Contract {r.contract_id}</strong> – Group {r.group_id} – {r.start_date.toLocaleDateString()} to {r.end_date.toLocaleDateString()} – Qty {r.quantity}
             </div>
-            <button
-              onClick={() => handleAllocate(r.id)}
-              disabled={allocationMutation.isPending && activeId === r.id}
-            >
-              {allocationMutation.isPending && activeId === r.id ? 'Allocating...' : 'Allocate Asset'}
-            </button>
+            <div>
+              <button
+                onClick={() => handleScore(r)}
+                disabled={scoreMutation.isPending && scoringId === r.id}
+              >
+                {scoreMutation.isPending && scoringId === r.id ? 'Scoring...' : 'Score Assets'}
+              </button>
+              <button
+                onClick={() => handleAllocate(r.id)}
+                disabled={allocationMutation.isPending && activeId === r.id}
+              >
+                {allocationMutation.isPending && activeId === r.id ? 'Allocating...' : 'Allocate Asset'}
+              </button>
+            </div>
+            {scores[r.id] && (
+              <ul>
+                {scores[r.id].map((s) => (
+                  <li key={s.asset_code}>
+                    {s.asset_code} – {s.score.toFixed(2)}
+                  </li>
+                ))}
+              </ul>
+            )}
             {allocationMutation.isError && activeId === r.id && (
               <div>Error allocating asset</div>
             )}
             {allocationMutation.isSuccess && activeId === r.id && (
-              <div>Asset allocated successfully!</div>
+              <div>
+                {allocationMutation.data?.external
+                  ? 'No internal asset available – external hire created.'
+                  : 'Asset allocated successfully!'}
+              </div>
             )}
           </li>
         ))}
       </ul>
-    </div>
+      </div>
   )
 }

--- a/FleetFlow/src/types.ts
+++ b/FleetFlow/src/types.ts
@@ -49,3 +49,9 @@ export const WeeklyGroupUtilizationSchema = z.object({
   on_hire_count: z.number(),
 })
 export type WeeklyGroupUtilization = z.infer<typeof WeeklyGroupUtilizationSchema>
+
+export const AssetScoreSchema = z.object({
+  asset_code: z.string(),
+  score: z.number(),
+})
+export type AssetScore = z.infer<typeof AssetScoreSchema>


### PR DESCRIPTION
## Summary
- add asset scoring types and query helper
- show open requests with score results
- create external hire when no internal asset available

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pre-commit run --files FleetFlow/src/types.ts FleetFlow/src/api/queries.ts FleetFlow/src/pages/PlantCoordinatorPage.tsx`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a45712c5b0832c98b1e0fcc8571245