### PR TITLE
Add Vitest tests for WeekCalendar and hooks

### DIFF
--- a/FleetFlow/package.json
+++ b/FleetFlow/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.55.0",
@@ -29,6 +30,7 @@
     "globals": "^16.3.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.1",
-    "vite": "^7.1.2"
+    "vite": "^7.1.2",
+    "vitest": "^3.2.4"
   }
 }

--- a/FleetFlow/src/api/queries.test.ts
+++ b/FleetFlow/src/api/queries.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi, type Mock } from 'vitest'
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: vi.fn(),
+}))
+vi.mock('../lib/supabase', () => ({
+  supabase: {},
+}))
+
+import { useQuery } from '@tanstack/react-query'
+import { useExampleQuery, fetchExample } from './queries'
+
+describe('useExampleQuery', () => {
+  it('calls useQuery with examples key and fetcher', () => {
+    const fakeResult = { data: [] }
+    ;(useQuery as Mock).mockReturnValue(fakeResult)
+
+    const result = useExampleQuery()
+
+    expect(useQuery).toHaveBeenCalledWith({
+      queryKey: ['examples'],
+      queryFn: fetchExample,
+    })
+    expect(result).toBe(fakeResult)
+  })
+})

--- a/FleetFlow/src/components/WeekCalendar.test.tsx
+++ b/FleetFlow/src/components/WeekCalendar.test.tsx
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { renderToString } from 'react-dom/server'
+import WeekCalendar from './WeekCalendar'
+
+describe('WeekCalendar', () => {
+  it('renders seven day buttons', () => {
+    const html = renderToString(
+      <WeekCalendar selectedDate={new Date('2024-02-14')} />
+    )
+    const matches = html.match(/<button class=\"day-label/g) ?? []
+    expect(matches.length).toBe(7)
+  })
+})

--- a/FleetFlow/src/lib/weeks.test.ts
+++ b/FleetFlow/src/lib/weeks.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest'
+import { getWeekDays } from './weeks'
+
+describe('getWeekDays', () => {
+  it('returns 7 days starting on Sunday', () => {
+    const days = getWeekDays(new Date('2024-02-14'))
+    expect(days).toHaveLength(7)
+    expect(days[0].getDay()).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
- add Vitest test script and install Vitest
- test React Query hook `useExampleQuery`
- test `WeekCalendar` component rendering
- test `getWeekDays` utility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a46ce97a50832c94f5863a769b8958