### PR TITLE
Format operator distance and add null distance test

### DIFF
--- a/FleetFlow/src/components/OperatorMatchList.test.tsx
+++ b/FleetFlow/src/components/OperatorMatchList.test.tsx
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { renderToString } from 'react-dom/server'
+import OperatorMatchList from './OperatorMatchList'
+
+describe('OperatorMatchList', () => {
+  it('renders N/A when distance is null', () => {
+    const html = renderToString(
+      <OperatorMatchList operators={[{ id: 1, distance_km: null }]} />
+    )
+    expect(html).toContain('N/A')
+  })
+})

--- a/FleetFlow/src/components/OperatorMatchList.tsx
+++ b/FleetFlow/src/components/OperatorMatchList.tsx
@@ -1,0 +1,22 @@
+import type { FC } from 'react'
+
+interface Operator {
+  id: number | string
+  distance_km: number | null
+}
+
+interface OperatorMatchListProps {
+  operators: Operator[]
+}
+
+const OperatorMatchList: FC<OperatorMatchListProps> = ({ operators }) => {
+  return (
+    <ul>
+      {operators.map((o) => (
+        <li key={o.id}>{o.distance_km?.toFixed(1) ?? 'N/A'} km</li>
+      ))}
+    </ul>
+  )
+}
+
+export default OperatorMatchList

--- a/FleetFlow/src/components/WeekCalendar.test.tsx
+++ b/FleetFlow/src/components/WeekCalendar.test.tsx
@@ -7,7 +7,7 @@ describe('WeekCalendar', () => {
     const html = renderToString(
       <WeekCalendar selectedDate={new Date('2024-02-14')} />
     )
-    const matches = html.match(/<button class=\"day-label/g) ?? []
+    const matches = html.match(/<button class="day-label/g) ?? []
     expect(matches.length).toBe(7)
   })
 })


### PR DESCRIPTION
## Summary
- format operator match distance values to one decimal place
- test that OperatorMatchList shows `N/A` when distance is null
- clean up WeekCalendar test regex to satisfy linter

## Testing
- `pre-commit run --files FleetFlow/src/components/OperatorMatchList.tsx FleetFlow/src/components/OperatorMatchList.test.tsx FleetFlow/src/components/WeekCalendar.test.tsx`
- `npm --prefix FleetFlow test`


------
https://chatgpt.com/codex/tasks/task_b_68a46e935eb4832cb41e0bb078ad402c