### PR TITLE
Filter unavailable operators in ranking

### DIFF
--- a/FleetFlow/README.md
+++ b/FleetFlow/README.md
@@ -135,6 +135,7 @@ Open [http://localhost:5173](http://localhost:5173) (or the port Vite shows). Th
 * `rpc_available_assets(group_id, start_date, end_date)`
 * `rpc_score_assets(group_id, start_date, end_date, site_lat, site_lon)` → returns ranked candidates
 * `rpc_allocate_best_asset(request_id, group_id, start_date, end_date, site_lat, site_lon)` → inserts allocation or raises `NO_INTERNAL_ASSET_AVAILABLE`
+* `rpc_rank_operators(start_date, end_date)` → lists available operators ordered by name, excluding those with overlapping assignments or unavailability
 
 ## Deployment
 

--- a/FleetFlow/supabase/rpc_rank_operators.sql
+++ b/FleetFlow/supabase/rpc_rank_operators.sql
@@ -1,0 +1,34 @@
+-- Function: rpc_rank_operators
+-- Description: Returns available operators ranked by name, excluding those
+--               with existing assignments or unavailability overlapping the
+--               requested dates.
+-- Parameters:
+--   req_start date - start date of the request
+--   req_end   date - end date of the request
+-- Returns: table(operator_id uuid, operator_name text)
+create or replace function rpc_rank_operators(
+  req_start date,
+  req_end date
+)
+returns table (
+  operator_id uuid,
+  operator_name text
+)
+language sql
+stable
+as $$
+  select o.id as operator_id,
+         o.name as operator_name
+  from operators o
+  left join operator_assignments oa
+    on oa.operator_id = o.id
+   and oa.start_date <= req_end
+   and oa.end_date >= req_start
+  left join operator_unavailability ou
+    on ou.operator_id = o.id
+   and ou.start_date <= req_end
+   and ou.end_date >= req_start
+  where oa.operator_id is null
+    and ou.operator_id is null
+  order by o.name;
+$$;


### PR DESCRIPTION
## Summary
- add SQL function to rank operators by excluding conflicts from assignments and unavailability
- document rpc_rank_operators in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a471793170832c9e94c72c6eb479b0