### PR TITLE
Enable operator ranking and assignment workflow

### DIFF
--- a/FleetFlow/src/App.tsx
+++ b/FleetFlow/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import CalendarPage from './pages/CalendarPage'
 import PlantCoordinatorPage from './pages/PlantCoordinatorPage'
+import WorkforceCoordinatorPage from './pages/WorkforceCoordinatorPage'
 
 export default function App() {
   return (
@@ -8,6 +9,10 @@ export default function App() {
       <Routes>
         <Route path="/" element={<CalendarPage />} />
         <Route path="/plant-coordinator" element={<PlantCoordinatorPage />} />
+        <Route
+          path="/workforce-coordinator"
+          element={<WorkforceCoordinatorPage />}
+        />
       </Routes>
     </BrowserRouter>
   )

--- a/FleetFlow/src/api/queries.ts
+++ b/FleetFlow/src/api/queries.ts
@@ -8,6 +8,8 @@ import {
   RequestSchema,
   WeeklyGroupUtilizationSchema,
   AssetScoreSchema,
+  OperatorMatchSchema,
+  OperatorAssignmentSchema,
   type Example,
   type CalendarEvent,
   type EquipmentGroup,
@@ -15,6 +17,8 @@ import {
   type Request,
   type WeeklyGroupUtilization,
   type AssetScore,
+  type OperatorMatch,
+  type OperatorAssignment,
 } from '../types'
 
 export const fetchExample = async (): Promise<Example[]> => {
@@ -111,4 +115,34 @@ export const useWeeklyGroupUtilizationQuery = () =>
   useQuery<WeeklyGroupUtilization[], Error>({
     queryKey: ['weekly-group-utilization'],
     queryFn: fetchWeeklyGroupUtilization,
+  })
+
+export const rankOperators = async (
+  startDate: Date,
+  endDate: Date,
+): Promise<OperatorMatch[]> => {
+  const { data, error } = await supabase.rpc('rpc_rank_operators', {
+    req_start: startDate.toISOString().slice(0, 10),
+    req_end: endDate.toISOString().slice(0, 10),
+  })
+  if (error) {
+    throw new Error(error.message)
+  }
+  return OperatorMatchSchema.array().parse(data ?? [])
+}
+
+export const fetchOperatorAssignments = async (): Promise<OperatorAssignment[]> => {
+  const { data, error } = await supabase
+    .from('operator_assignments')
+    .select('*')
+  if (error) {
+    throw new Error(error.message)
+  }
+  return OperatorAssignmentSchema.array().parse(data ?? [])
+}
+
+export const useOperatorAssignmentsQuery = () =>
+  useQuery<OperatorAssignment[], Error>({
+    queryKey: ['operator-assignments'],
+    queryFn: fetchOperatorAssignments,
   })

--- a/FleetFlow/src/components/OperatorMatchList.test.tsx
+++ b/FleetFlow/src/components/OperatorMatchList.test.tsx
@@ -5,8 +5,19 @@ import OperatorMatchList from './OperatorMatchList'
 describe('OperatorMatchList', () => {
   it('renders N/A when distance is null', () => {
     const html = renderToString(
-      <OperatorMatchList operators={[{ id: 1, distance_km: null }]} />
+      <OperatorMatchList operators={[{ id: 1, name: 'Jane', distance_km: null }]} />
     )
     expect(html).toContain('N/A')
+    expect(html).toContain('Jane')
+  })
+
+  it('renders assign button when callback provided', () => {
+    const html = renderToString(
+      <OperatorMatchList
+        operators={[{ id: 2, name: 'Bob', distance_km: 1.2 }]}
+        onAssign={() => {}}
+      />
+    )
+    expect(html).toContain('Assign')
   })
 })

--- a/FleetFlow/src/components/OperatorMatchList.tsx
+++ b/FleetFlow/src/components/OperatorMatchList.tsx
@@ -2,18 +2,28 @@ import type { FC } from 'react'
 
 interface Operator {
   id: number | string
+  name: string
   distance_km: number | null
 }
 
 interface OperatorMatchListProps {
   operators: Operator[]
+  onAssign?: (id: number | string) => void
 }
 
-const OperatorMatchList: FC<OperatorMatchListProps> = ({ operators }) => {
+const OperatorMatchList: FC<OperatorMatchListProps> = ({
+  operators,
+  onAssign,
+}) => {
   return (
     <ul>
       {operators.map((o) => (
-        <li key={o.id}>{o.distance_km?.toFixed(1) ?? 'N/A'} km</li>
+        <li key={o.id}>
+          {o.name} – {o.distance_km?.toFixed(1) ?? 'N/A'} km
+          {onAssign && (
+            <button onClick={() => onAssign(o.id)}>Assign</button>
+          )}
+        </li>
       ))}
     </ul>
   )

--- a/FleetFlow/src/pages/WorkforceCoordinatorPage.tsx
+++ b/FleetFlow/src/pages/WorkforceCoordinatorPage.tsx
@@ -1,0 +1,128 @@
+import { useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  useRequestsQuery,
+  useOperatorAssignmentsQuery,
+  rankOperators,
+} from '../api/queries'
+import type { Request, OperatorMatch } from '../types'
+import { supabase } from '../lib/supabase'
+import OperatorMatchList from '../components/OperatorMatchList'
+
+export default function WorkforceCoordinatorPage() {
+  const { data: requests, isLoading, error } = useRequestsQuery()
+  const { data: assignments } = useOperatorAssignmentsQuery()
+  const queryClient = useQueryClient()
+  const [rankingId, setRankingId] = useState<string | null>(null)
+  const [assigningId, setAssigningId] = useState<string | null>(null)
+  const [matches, setMatches] = useState<Record<string, OperatorMatch[]>>({})
+
+  const rankMutation = useMutation({
+    mutationFn: (request: Request) =>
+      rankOperators(request.start_date, request.end_date),
+    onSuccess: (data, variables) => {
+      setMatches((prev) => ({ ...prev, [variables.id]: data }))
+    },
+  })
+
+  const assignMutation = useMutation({
+    mutationFn: async ({
+      requestId,
+      operatorId,
+      startDate,
+      endDate,
+    }: {
+      requestId: string
+      operatorId: string
+      startDate: Date
+      endDate: Date
+    }) => {
+      const { error } = await supabase.from('operator_assignments').insert({
+        request_id: requestId,
+        operator_id: operatorId,
+        start_date: startDate.toISOString(),
+        end_date: endDate.toISOString(),
+      })
+      if (error) {
+        throw new Error(error.message)
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['operator-assignments'] })
+    },
+  })
+
+  const openRequests = requests?.filter((r) => {
+    if (!r.operated) return false
+    const count =
+      assignments?.filter((a) => a.request_id === r.id).length ?? 0
+    return count < r.quantity
+  })
+
+  const handleRank = (r: Request) => {
+    setRankingId(r.id)
+    rankMutation.mutate(r)
+  }
+
+  const handleAssign = (r: Request, operatorId: string) => {
+    setAssigningId(r.id)
+    assignMutation.mutate({
+      requestId: r.id,
+      operatorId,
+      startDate: r.start_date,
+      endDate: r.end_date,
+    })
+  }
+
+  if (isLoading) {
+    return <div>Loading requests...</div>
+  }
+
+  if (error) {
+    return <div>Error: {error.message}</div>
+  }
+
+  return (
+    <div>
+      <h1>Workforce Coordinator</h1>
+      <ul>
+        {openRequests?.map((r) => (
+          <li key={r.id}>
+            <div>
+              <strong>Contract {r.contract_id}</strong> – Group {r.group_id} –
+              {r.start_date.toLocaleDateString()} to
+              {r.end_date.toLocaleDateString()} – Qty {r.quantity}
+            </div>
+            <div>
+              <button
+                onClick={() => handleRank(r)}
+                disabled={rankMutation.isPending && rankingId === r.id}
+              >
+                {rankMutation.isPending && rankingId === r.id
+                  ? 'Ranking...'
+                  : 'Rank Operators'}
+              </button>
+            </div>
+            {matches[r.id] && (
+              <OperatorMatchList
+                operators={matches[r.id].map((m) => ({
+                  id: m.operator_id,
+                  name: m.operator_name,
+                  distance_km: null,
+                }))}
+                onAssign={(opId) => handleAssign(r, String(opId))}
+              />
+            )}
+            {assignMutation.isError && assigningId === r.id && (
+              <div>Error assigning operator</div>
+            )}
+            {assignMutation.isSuccess && assigningId === r.id && (
+              <div>Operator assigned!</div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+

--- a/FleetFlow/src/types.ts
+++ b/FleetFlow/src/types.ts
@@ -55,3 +55,18 @@ export const AssetScoreSchema = z.object({
   score: z.number(),
 })
 export type AssetScore = z.infer<typeof AssetScoreSchema>
+
+export const OperatorMatchSchema = z.object({
+  operator_id: z.string(),
+  operator_name: z.string(),
+})
+export type OperatorMatch = z.infer<typeof OperatorMatchSchema>
+
+export const OperatorAssignmentSchema = z.object({
+  id: z.string(),
+  request_id: z.string(),
+  operator_id: z.string(),
+  start_date: z.coerce.date(),
+  end_date: z.coerce.date(),
+})
+export type OperatorAssignment = z.infer<typeof OperatorAssignmentSchema>


### PR DESCRIPTION
## Summary
- add operator ranking and assignment queries
- show ranked operators in OperatorMatchList with assign button
- introduce Workforce Coordinator page and route for assigning operators

## Testing
- `npm test`
- `pre-commit run --files FleetFlow/src/types.ts FleetFlow/src/api/queries.ts FleetFlow/src/components/OperatorMatchList.tsx FleetFlow/src/components/OperatorMatchList.test.tsx FleetFlow/src/pages/WorkforceCoordinatorPage.tsx FleetFlow/src/App.tsx`


------
https://chatgpt.com/codex/tasks/task_b_68a47ae0f49c832cb46cc8045caab0c0