### PR TITLE
feat: add event details drawer

### DIFF
--- a/FleetFlow/package.json
+++ b/FleetFlow/package.json
@@ -14,6 +14,7 @@
     "@supabase/supabase-js": "^2.55.0",
     "@tanstack/react-query": "^5.85.0",
     "@tanstack/react-query-devtools": "^5.85.0",
+    "@radix-ui/react-dialog": "^1.0.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.8.0",
@@ -21,6 +22,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
+    "@testing-library/react": "^16.0.0",
+    "jsdom": "^24.0.0",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",

--- a/FleetFlow/src/components/EventDetailsDrawer.test.tsx
+++ b/FleetFlow/src/components/EventDetailsDrawer.test.tsx
@@ -1,0 +1,20 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import EventDetailsDrawer from './EventDetailsDrawer'
+import type { CalendarEvent } from '../types'
+
+describe('EventDetailsDrawer', () => {
+  it('renders action buttons when open', () => {
+    const event: CalendarEvent = {
+      id: '1',
+      title: 'Test Event',
+      date: new Date('2024-01-01'),
+    }
+    render(
+      <EventDetailsDrawer event={event} open={true} onClose={() => {}} />,
+    )
+    expect(screen.getByText('Off-hire')).toBeTruthy()
+    expect(screen.getByText('Reassign')).toBeTruthy()
+  })
+})

--- a/FleetFlow/src/components/EventDetailsDrawer.tsx
+++ b/FleetFlow/src/components/EventDetailsDrawer.tsx
@@ -1,0 +1,45 @@
+import * as Dialog from '@radix-ui/react-dialog'
+import type { CalendarEvent } from '../types'
+import './week-calendar.css'
+
+export interface EventDetailsDrawerProps {
+  event: CalendarEvent | null
+  open: boolean
+  onClose: () => void
+  onOffHire?: (event: CalendarEvent) => void
+  onReassign?: (event: CalendarEvent) => void
+}
+
+export default function EventDetailsDrawer({
+  event,
+  open,
+  onClose,
+  onOffHire,
+  onReassign,
+}: EventDetailsDrawerProps) {
+  return (
+    <Dialog.Root open={open} onOpenChange={(o) => !o && onClose()}>
+      <Dialog.Portal>
+        <Dialog.Overlay className='drawer-overlay' />
+        <Dialog.Content className='drawer-content'>
+          <Dialog.Title>Details</Dialog.Title>
+          {event && (
+            <div className='drawer-body'>
+              <p>{event.title}</p>
+              <p>{event.date.toDateString()}</p>
+            </div>
+          )}
+          <div className='drawer-actions'>
+            <button onClick={() => event && onOffHire?.(event)}>
+              Off-hire
+            </button>
+            <button onClick={() => event && onReassign?.(event)}>
+              Reassign
+            </button>
+          </div>
+          <Dialog.Close className='drawer-close'>Close</Dialog.Close>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/FleetFlow/src/components/WeekCalendar.tsx
+++ b/FleetFlow/src/components/WeekCalendar.tsx
@@ -1,9 +1,11 @@
+import { useState } from 'react'
 import { getWeekDays } from '../lib/weeks'
 import type {
   CalendarEvent,
   EquipmentGroup,
   WeeklyGroupUtilization,
 } from '../types'
+import EventDetailsDrawer from './EventDetailsDrawer'
 import './week-calendar.css'
 
 export interface WeekCalendarProps {
@@ -14,6 +16,8 @@ export interface WeekCalendarProps {
   onSelectDate?: (date: Date) => void
   onPrevWeek?: () => void
   onNextWeek?: () => void
+  onOffHire?: (event: CalendarEvent) => void
+  onReassign?: (event: CalendarEvent) => void
 }
 
 export default function WeekCalendar({
@@ -24,9 +28,14 @@ export default function WeekCalendar({
   onSelectDate,
   onPrevWeek,
   onNextWeek,
+  onOffHire,
+  onReassign,
 }: WeekCalendarProps) {
   const days = getWeekDays(selectedDate)
   const weekStart = days[0]
+  const [selectedEvent, setSelectedEvent] = useState<CalendarEvent | null>(
+    null,
+  )
 
   return (
     <div>
@@ -59,9 +68,13 @@ export default function WeekCalendar({
                   {label}
                 </button>
                 {dayEvents.map((ev) => (
-                  <div key={ev.id} className='event'>
+                  <button
+                    key={ev.id}
+                    className='event'
+                    onClick={() => setSelectedEvent(ev)}
+                  >
                     {ev.title}
-                  </div>
+                  </button>
                 ))}
               </div>
             )
@@ -101,6 +114,13 @@ export default function WeekCalendar({
           </tbody>
         </table>
       )}
+      <EventDetailsDrawer
+        event={selectedEvent}
+        open={selectedEvent !== null}
+        onClose={() => setSelectedEvent(null)}
+        onOffHire={onOffHire}
+        onReassign={onReassign}
+      />
     </div>
   )
 }

--- a/FleetFlow/src/components/week-calendar.css
+++ b/FleetFlow/src/components/week-calendar.css
@@ -19,6 +19,9 @@
 
 .week-calendar .event {
   font-size: 0.75rem;
+  background: none;
+  border: none;
+  cursor: pointer;
 }
 
 .week-calendar .day-label {
@@ -50,4 +53,30 @@
   border: 1px solid #ccc;
   padding: 0.25rem;
   text-align: center;
+}
+
+.drawer-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.3);
+}
+
+.drawer-content {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 300px;
+  background: #fff;
+  padding: 1rem;
+  box-shadow: -2px 0 5px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.drawer-actions {
+  margin-top: auto;
+  display: flex;
+  gap: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- add Radix-powered drawer for event details with off-hire and reassign actions
- wire WeekCalendar events to open drawer on click
- cover drawer rendering with tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a47fb0923c832cbe614111224c6e2f