### PR TITLE
feat: add calendar filters

### DIFF
--- a/FleetFlow/src/pages/CalendarPage.tsx
+++ b/FleetFlow/src/pages/CalendarPage.tsx
@@ -10,6 +10,9 @@ import {
 
 export default function CalendarPage() {
   const [selectedDate, setSelectedDate] = useState(new Date())
+  const [siteFilter, setSiteFilter] = useState('all')
+  const [statusFilter, setStatusFilter] = useState('all')
+  const [operatedFilter, setOperatedFilter] = useState('all')
   const { data: events, isLoading, error } = useEventsQuery()
   const { data: groups } = useEquipmentGroupsQuery()
   const { data: allocations } = useAllocationsQuery()
@@ -29,9 +32,72 @@ export default function CalendarPage() {
   const handleNextWeek = () =>
     setSelectedDate(new Date(selectedDate.getTime() + 7 * 24 * 60 * 60 * 1000))
 
+  const sites = Array.from(
+    new Set(events?.map((e) => e.site).filter((s): s is string => Boolean(s)))
+  )
+  const statuses = Array.from(
+    new Set(
+      events
+        ?.map((e) => e.contract_status)
+        .filter((s): s is string => Boolean(s)),
+    ),
+  )
+
+  const filteredEvents =
+    events?.filter((ev) => {
+      if (siteFilter !== 'all' && ev.site !== siteFilter) return false
+      if (statusFilter !== 'all' && ev.contract_status !== statusFilter)
+        return false
+      if (operatedFilter === 'operated' && !ev.operated) return false
+      if (operatedFilter === 'non-operated' && ev.operated) return false
+      return true
+    }) ?? []
+
   return (
     <div>
       <h1>Calendar</h1>
+      <section>
+        <h2>Filters</h2>
+        <label>
+          Site:
+          <select
+            value={siteFilter}
+            onChange={(e) => setSiteFilter(e.target.value)}
+          >
+            <option value='all'>All</option>
+            {sites.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Status:
+          <select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+          >
+            <option value='all'>All</option>
+            {statuses.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Operated:
+          <select
+            value={operatedFilter}
+            onChange={(e) => setOperatedFilter(e.target.value)}
+          >
+            <option value='all'>All</option>
+            <option value='operated'>Operated</option>
+            <option value='non-operated'>Non-operated</option>
+          </select>
+        </label>
+      </section>
       <section>
         <h2>Equipment Groups</h2>
         <ul>
@@ -44,7 +110,7 @@ export default function CalendarPage() {
       </section>
       <WeekCalendar
         selectedDate={selectedDate}
-        events={events ?? []}
+        events={filteredEvents}
         utilization={utilization ?? []}
         groups={groups ?? []}
         onSelectDate={setSelectedDate}

--- a/FleetFlow/src/types.ts
+++ b/FleetFlow/src/types.ts
@@ -10,6 +10,9 @@ export const CalendarEventSchema = z.object({
   id: z.string(),
   date: z.coerce.date(),
   title: z.string(),
+  site: z.string().optional(),
+  contract_status: z.string().optional(),
+  operated: z.boolean().optional(),
 })
 export type CalendarEvent = z.infer<typeof CalendarEventSchema>
 


### PR DESCRIPTION
## Summary
- add optional `site`, `contract_status`, and `operated` fields to calendar events
- filter calendar events by site, contract status, and operated flag

## Testing
- `npm test`
- `pre-commit run --files FleetFlow/src/types.ts FleetFlow/src/pages/CalendarPage.tsx`

------
https://chatgpt.com/codex/tasks/task_b_68a482deb714832ca02eeccfff244b8b