### PR TITLE
Implement role-based route protection with Supabase auth

### DIFF
--- a/FleetFlow/src/App.tsx
+++ b/FleetFlow/src/App.tsx
@@ -2,18 +2,42 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import CalendarPage from './pages/CalendarPage'
 import PlantCoordinatorPage from './pages/PlantCoordinatorPage'
 import WorkforceCoordinatorPage from './pages/WorkforceCoordinatorPage'
+import LoginPage from './pages/LoginPage'
+import ProtectedRoute from './components/ProtectedRoute'
+import { AuthProvider } from './components/AuthProvider'
 
 export default function App() {
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<CalendarPage />} />
-        <Route path="/plant-coordinator" element={<PlantCoordinatorPage />} />
-        <Route
-          path="/workforce-coordinator"
-          element={<WorkforceCoordinatorPage />}
-        />
-      </Routes>
-    </BrowserRouter>
+    <AuthProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route path='/login' element={<LoginPage />} />
+          <Route
+            path='/'
+            element={
+              <ProtectedRoute>
+                <CalendarPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path='/plant-coordinator'
+            element={
+              <ProtectedRoute roles={['plant_coordinator']}>
+                <PlantCoordinatorPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path='/workforce-coordinator'
+            element={
+              <ProtectedRoute roles={['workforce_coordinator']}>
+                <WorkforceCoordinatorPage />
+              </ProtectedRoute>
+            }
+          />
+        </Routes>
+      </BrowserRouter>
+    </AuthProvider>
   )
 }

--- a/FleetFlow/src/components/AuthProvider.tsx
+++ b/FleetFlow/src/components/AuthProvider.tsx
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react'
+import type { User } from '@supabase/supabase-js'
+import { supabase } from '../lib/supabase'
+import { AuthContext } from './auth-context'
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => {
+      setUser(data.user)
+    })
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null)
+    })
+    return () => {
+      subscription.unsubscribe()
+    }
+  }, [])
+
+  return <AuthContext.Provider value={{ user }}>{children}</AuthContext.Provider>
+}
+

--- a/FleetFlow/src/components/ProtectedRoute.test.tsx
+++ b/FleetFlow/src/components/ProtectedRoute.test.tsx
@@ -1,0 +1,55 @@
+/** @vitest-environment jsdom */
+import { describe, expect, it } from 'vitest'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { render, screen } from '@testing-library/react'
+import ProtectedRoute from './ProtectedRoute'
+import { AuthContext } from './auth-context'
+import type { User } from '@supabase/supabase-js'
+
+describe('ProtectedRoute', () => {
+  it('redirects to login when user is not authenticated', () => {
+    render(
+      <AuthContext.Provider value={{ user: null }}>
+        <MemoryRouter initialEntries={['/protected']}>
+          <Routes>
+            <Route path='/login' element={<div>Login Page</div>} />
+            <Route
+              path='/protected'
+              element={
+                <ProtectedRoute>
+                  <div>Secret</div>
+                </ProtectedRoute>
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      </AuthContext.Provider>
+    )
+
+    expect(screen.getByText('Login Page')).toBeTruthy()
+  })
+
+  it('renders children when role matches', () => {
+    render(
+      <AuthContext.Provider
+        value={{ user: { user_metadata: { role: 'plant_coordinator' } } as unknown as User }}
+      >
+        <MemoryRouter initialEntries={['/protected']}>
+          <Routes>
+            <Route
+              path='/protected'
+              element={
+                <ProtectedRoute roles={['plant_coordinator']}>
+                  <div>Secret</div>
+                </ProtectedRoute>
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      </AuthContext.Provider>
+    )
+
+    expect(screen.getByText('Secret')).toBeTruthy()
+  })
+})
+

--- a/FleetFlow/src/components/ProtectedRoute.tsx
+++ b/FleetFlow/src/components/ProtectedRoute.tsx
@@ -1,0 +1,25 @@
+import { Navigate } from 'react-router-dom'
+import type { ReactNode } from 'react'
+import { useAuth } from './auth-context'
+
+export default function ProtectedRoute({
+  children,
+  roles,
+}: {
+  children: ReactNode
+  roles?: string[]
+}) {
+  const { user } = useAuth()
+
+  if (!user) {
+    return <Navigate to='/login' replace />
+  }
+
+  const userRole = (user.user_metadata as { role?: string } | undefined)?.role
+  if (roles && (!userRole || !roles.includes(userRole))) {
+    return <Navigate to='/' replace />
+  }
+
+  return <>{children}</>
+}
+

--- a/FleetFlow/src/components/auth-context.ts
+++ b/FleetFlow/src/components/auth-context.ts
@@ -1,0 +1,13 @@
+import { createContext, useContext } from 'react'
+import type { User } from '@supabase/supabase-js'
+
+export interface AuthContextValue {
+  user: User | null
+}
+
+export const AuthContext = createContext<AuthContextValue>({ user: null })
+
+export function useAuth() {
+  return useContext(AuthContext)
+}
+

--- a/FleetFlow/src/pages/LoginPage.tsx
+++ b/FleetFlow/src/pages/LoginPage.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react'
+import { supabase } from '../lib/supabase'
+import { useNavigate } from 'react-router-dom'
+
+export default function LoginPage() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const navigate = useNavigate()
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const { error: signInError } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    })
+    if (signInError) {
+      setError(signInError.message)
+      return
+    }
+    navigate('/')
+  }
+
+  return (
+    <div>
+      <h1>Login</h1>
+      <form onSubmit={handleSubmit}>
+        <label>
+          Email
+          <input
+            type='email'
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </label>
+        <label>
+          Password
+          <input
+            type='password'
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </label>
+        <button type='submit'>Sign In</button>
+        {error && <div>{error}</div>}
+      </form>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add authentication context backed by Supabase
- protect routes with role-based `<ProtectedRoute>` component
- add login page and tests for auth guards

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a48427de80832caff17a64328e5eea