### PR TITLE
Add validation for hires and operator assignments

### DIFF
--- a/FleetFlow/src/pages/PlantCoordinatorPage.tsx
+++ b/FleetFlow/src/pages/PlantCoordinatorPage.tsx
@@ -7,6 +7,7 @@ import {
 } from '../api/queries'
 import type { Request, AssetScore } from '../types'
 import { supabase } from '../lib/supabase'
+import { validateExternalHire } from '../utils/validation'
 
 export default function PlantCoordinatorPage() {
   const { data: requests, isLoading, error } = useRequestsQuery()
@@ -36,6 +37,7 @@ export default function PlantCoordinatorPage() {
         })
         if (error) {
           if (error.message === 'NO_INTERNAL_ASSET_AVAILABLE') {
+            await validateExternalHire(request.group_id)
             const { error: hireError } = await supabase
               .from('external_hires')
               .insert({ request_id: request.id })

--- a/FleetFlow/src/pages/WorkforceCoordinatorPage.tsx
+++ b/FleetFlow/src/pages/WorkforceCoordinatorPage.tsx
@@ -8,6 +8,7 @@ import {
 import type { Request, OperatorMatch } from '../types'
 import { supabase } from '../lib/supabase'
 import OperatorMatchList from '../components/OperatorMatchList'
+import { validateOperatorAssignment } from '../utils/validation'
 
 export default function WorkforceCoordinatorPage() {
   const { data: requests, isLoading, error } = useRequestsQuery()
@@ -28,15 +29,18 @@ export default function WorkforceCoordinatorPage() {
   const assignMutation = useMutation({
     mutationFn: async ({
       requestId,
+      groupId,
       operatorId,
       startDate,
       endDate,
     }: {
       requestId: string
+      groupId: string
       operatorId: string
       startDate: Date
       endDate: Date
     }) => {
+      await validateOperatorAssignment(groupId, operatorId)
       const { error } = await supabase.from('operator_assignments').insert({
         request_id: requestId,
         operator_id: operatorId,
@@ -68,6 +72,7 @@ export default function WorkforceCoordinatorPage() {
     setAssigningId(r.id)
     assignMutation.mutate({
       requestId: r.id,
+      groupId: r.group_id,
       operatorId,
       startDate: r.start_date,
       endDate: r.end_date,

--- a/FleetFlow/src/types.ts
+++ b/FleetFlow/src/types.ts
@@ -73,3 +73,21 @@ export const OperatorAssignmentSchema = z.object({
   end_date: z.coerce.date(),
 })
 export type OperatorAssignment = z.infer<typeof OperatorAssignmentSchema>
+
+export const GroupSubstitutionSchema = z.object({
+  group_id: z.string(),
+  substitute_group_id: z.string(),
+})
+export type GroupSubstitution = z.infer<typeof GroupSubstitutionSchema>
+
+export const OperatorTicketSchema = z.object({
+  operator_id: z.string(),
+  ticket_code: z.string(),
+})
+export type OperatorTicket = z.infer<typeof OperatorTicketSchema>
+
+export const GroupRequiredTicketSchema = z.object({
+  group_id: z.string(),
+  ticket_code: z.string(),
+})
+export type GroupRequiredTicket = z.infer<typeof GroupRequiredTicketSchema>

--- a/FleetFlow/src/utils/validation.test.ts
+++ b/FleetFlow/src/utils/validation.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
+
+vi.mock('../lib/supabase', () => {
+  return {
+    supabase: {
+      from: vi.fn(),
+    },
+  }
+})
+
+import { validateExternalHire, validateOperatorAssignment } from './validation'
+import { supabase } from '../lib/supabase'
+
+describe('validateExternalHire', () => {
+  beforeEach(() => {
+    ;(supabase.from as Mock).mockReset()
+  })
+
+  it('throws when substitution exists', async () => {
+    const eq = vi.fn().mockResolvedValue({
+      data: [{ group_id: '1', substitute_group_id: '2' }],
+      error: null,
+    })
+    const select = vi.fn(() => ({ eq }))
+    ;(supabase.from as Mock).mockReturnValue({ select })
+    await expect(validateExternalHire('1')).rejects.toThrow('SUBSTITUTION_AVAILABLE')
+  })
+
+  it('passes when no substitution', async () => {
+    const eq = vi.fn().mockResolvedValue({ data: [], error: null })
+    const select = vi.fn(() => ({ eq }))
+    ;(supabase.from as Mock).mockReturnValue({ select })
+    await expect(validateExternalHire('1')).resolves.toBeUndefined()
+  })
+})
+
+describe('validateOperatorAssignment', () => {
+  beforeEach(() => {
+    ;(supabase.from as Mock).mockReset()
+  })
+
+  it('throws when operator missing required tickets', async () => {
+    const from = supabase.from as Mock
+    from.mockImplementation((table: string) => {
+      if (table === 'group_required_tickets') {
+        const eq = vi.fn().mockResolvedValue({
+          data: [{ group_id: '1', ticket_code: 'A' }],
+          error: null,
+        })
+        return { select: () => ({ eq }) }
+      }
+      if (table === 'operator_tickets') {
+        const eq = vi.fn().mockResolvedValue({
+          data: [{ operator_id: 'op', ticket_code: 'B' }],
+          error: null,
+        })
+        return { select: () => ({ eq }) }
+      }
+      return { select: () => ({ eq: vi.fn() }) }
+    })
+
+    await expect(validateOperatorAssignment('1', 'op')).rejects.toThrow(
+      'MISSING_REQUIRED_TICKETS',
+    )
+  })
+
+  it('passes when operator has required tickets', async () => {
+    const from = supabase.from as Mock
+    from.mockImplementation((table: string) => {
+      if (table === 'group_required_tickets') {
+        const eq = vi.fn().mockResolvedValue({
+          data: [
+            { group_id: '1', ticket_code: 'A' },
+            { group_id: '1', ticket_code: 'B' },
+          ],
+          error: null,
+        })
+        return { select: () => ({ eq }) }
+      }
+      if (table === 'operator_tickets') {
+        const eq = vi.fn().mockResolvedValue({
+          data: [
+            { operator_id: 'op', ticket_code: 'A' },
+            { operator_id: 'op', ticket_code: 'B' },
+          ],
+          error: null,
+        })
+        return { select: () => ({ eq }) }
+      }
+      return { select: () => ({ eq: vi.fn() }) }
+    })
+
+    await expect(validateOperatorAssignment('1', 'op')).resolves.toBeUndefined()
+  })
+})

--- a/FleetFlow/src/utils/validation.ts
+++ b/FleetFlow/src/utils/validation.ts
@@ -1,0 +1,53 @@
+import { supabase } from '../lib/supabase'
+import {
+  GroupSubstitutionSchema,
+  GroupRequiredTicketSchema,
+  OperatorTicketSchema,
+} from '../types'
+
+export async function validateExternalHire(groupId: string): Promise<void> {
+  const { data, error } = await supabase
+    .from('group_substitutions')
+    .select('*')
+    .eq('group_id', groupId)
+  if (error) {
+    throw new Error(error.message)
+  }
+  const substitutions = GroupSubstitutionSchema.array().parse(data ?? [])
+  if (substitutions.length > 0) {
+    throw new Error('SUBSTITUTION_AVAILABLE')
+  }
+}
+
+export async function validateOperatorAssignment(
+  groupId: string,
+  operatorId: string,
+): Promise<void> {
+  const { data: requiredData, error: requiredError } = await supabase
+    .from('group_required_tickets')
+    .select('ticket_code')
+    .eq('group_id', groupId)
+  if (requiredError) {
+    throw new Error(requiredError.message)
+  }
+  const required = GroupRequiredTicketSchema.array().parse(requiredData ?? [])
+  if (required.length === 0) {
+    return
+  }
+
+  const { data: operatorData, error: operatorError } = await supabase
+    .from('operator_tickets')
+    .select('ticket_code')
+    .eq('operator_id', operatorId)
+  if (operatorError) {
+    throw new Error(operatorError.message)
+  }
+  const operatorTickets = OperatorTicketSchema.array().parse(operatorData ?? [])
+
+  const missing = required.filter(
+    (rt) => !operatorTickets.some((ot) => ot.ticket_code === rt.ticket_code),
+  )
+  if (missing.length > 0) {
+    throw new Error('MISSING_REQUIRED_TICKETS')
+  }
+}


### PR DESCRIPTION
## Summary
- prevent external hires when group substitutions exist
- validate operator assignments against required tickets
- add utility validators and accompanying tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a4879db8a0832cb1dd7b8aacf1aca4