### PR TITLE
feat: add off-hire and reassign allocation flows

### DIFF
--- a/FleetFlow/src/api/queries.ts
+++ b/FleetFlow/src/api/queries.ts
@@ -131,6 +131,29 @@ export const rankOperators = async (
   return OperatorMatchSchema.array().parse(data ?? [])
 }
 
+export const offHireAllocation = async (
+  allocationId: string,
+): Promise<void> => {
+  const { error } = await supabase.rpc('rpc_off_hire_allocation', {
+    allocation_id: allocationId,
+  })
+  if (error) {
+    throw new Error(error.message)
+  }
+}
+
+export const reassignAllocation = async (
+  allocationId: string,
+): Promise<CalendarEvent> => {
+  const { data, error } = await supabase.rpc('rpc_reassign_allocation', {
+    allocation_id: allocationId,
+  })
+  if (error) {
+    throw new Error(error.message)
+  }
+  return CalendarEventSchema.parse(data)
+}
+
 export const fetchOperatorAssignments = async (): Promise<OperatorAssignment[]> => {
   const { data, error } = await supabase
     .from('operator_assignments')

--- a/FleetFlow/src/components/EventDetailsDrawer.test.tsx
+++ b/FleetFlow/src/components/EventDetailsDrawer.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { describe, expect, it } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
 import EventDetailsDrawer from './EventDetailsDrawer'
 import type { CalendarEvent } from '../types'
 
@@ -16,5 +16,30 @@ describe('EventDetailsDrawer', () => {
     )
     expect(screen.getByText('Off-hire')).toBeTruthy()
     expect(screen.getByText('Reassign')).toBeTruthy()
+  })
+})
+
+describe('EventDetailsDrawer callbacks', () => {
+  it('invokes handlers when action buttons are clicked', () => {
+    const event: CalendarEvent = {
+      id: '1',
+      title: 'Test Event',
+      date: new Date('2024-01-01'),
+    }
+    const offHire = vi.fn()
+    const reassign = vi.fn()
+    render(
+      <EventDetailsDrawer
+        event={event}
+        open={true}
+        onClose={() => {}}
+        onOffHire={offHire}
+        onReassign={reassign}
+      />,
+    )
+    fireEvent.click(screen.getAllByText('Off-hire').at(-1)!)
+    expect(offHire).toHaveBeenCalledWith(event)
+    fireEvent.click(screen.getAllByText('Reassign').at(-1)!)
+    expect(reassign).toHaveBeenCalledWith(event)
   })
 })

--- a/FleetFlow/supabase/rpc_off_hire_allocation.sql
+++ b/FleetFlow/supabase/rpc_off_hire_allocation.sql
@@ -1,0 +1,15 @@
+-- Function: rpc_off_hire_allocation
+-- Description: Marks an allocation as off hire by setting the end date to today.
+-- Parameters:
+--   allocation_id uuid - allocation to off hire
+-- Returns: void
+create or replace function rpc_off_hire_allocation(
+  allocation_id uuid
+)
+returns void
+language sql
+as $$
+  update allocations
+     set end_date = current_date
+   where id = allocation_id;
+$$;

--- a/FleetFlow/supabase/rpc_reassign_allocation.sql
+++ b/FleetFlow/supabase/rpc_reassign_allocation.sql
@@ -1,0 +1,17 @@
+-- Function: rpc_reassign_allocation
+-- Description: Moves an allocation forward by one day.
+-- Parameters:
+--   allocation_id uuid - allocation to move
+-- Returns: allocations row after update
+create or replace function rpc_reassign_allocation(
+  allocation_id uuid
+)
+returns setof allocations
+language sql
+as $$
+  update allocations
+     set start_date = start_date + interval '1 day',
+         end_date   = end_date + interval '1 day'
+   where id = allocation_id
+  returning *;
+$$;


### PR DESCRIPTION
## Summary
- wire EventDetailsDrawer buttons to off-hire and reassign callbacks
- implement Supabase RPCs and query helpers for off-hire and reassignment
- update CalendarPage to call RPCs and adjust events after success

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a48a5d8838832cb2b74979dc059bd1