### PR TITLE
feat: add operator distance ranking

### DIFF
--- a/FleetFlow/src/api/queries.ts
+++ b/FleetFlow/src/api/queries.ts
@@ -120,10 +120,14 @@ export const useWeeklyGroupUtilizationQuery = () =>
 export const rankOperators = async (
   startDate: Date,
   endDate: Date,
+  siteLat: number,
+  siteLon: number,
 ): Promise<OperatorMatch[]> => {
   const { data, error } = await supabase.rpc('rpc_rank_operators', {
     req_start: startDate.toISOString().slice(0, 10),
     req_end: endDate.toISOString().slice(0, 10),
+    site_lat: siteLat,
+    site_lon: siteLon,
   })
   if (error) {
     throw new Error(error.message)

--- a/FleetFlow/src/components/OperatorMatchList.test.tsx
+++ b/FleetFlow/src/components/OperatorMatchList.test.tsx
@@ -20,4 +20,16 @@ describe('OperatorMatchList', () => {
     )
     expect(html).toContain('Assign')
   })
+
+  it('sorts by distance ascending', () => {
+    const html = renderToString(
+      <OperatorMatchList
+        operators={[
+          { id: 1, name: 'Far', distance_km: 10 },
+          { id: 2, name: 'Near', distance_km: 5 },
+        ]}
+      />,
+    )
+    expect(html.indexOf('Near')).toBeLessThan(html.indexOf('Far'))
+  })
 })

--- a/FleetFlow/src/components/OperatorMatchList.tsx
+++ b/FleetFlow/src/components/OperatorMatchList.tsx
@@ -15,9 +15,15 @@ const OperatorMatchList: FC<OperatorMatchListProps> = ({
   operators,
   onAssign,
 }) => {
+  const sorted = [...operators].sort((a, b) => {
+    if (a.distance_km == null) return 1
+    if (b.distance_km == null) return -1
+    return a.distance_km - b.distance_km
+  })
+
   return (
     <ul>
-      {operators.map((o) => (
+      {sorted.map((o) => (
         <li key={o.id}>
           {o.name} – {o.distance_km?.toFixed(1) ?? 'N/A'} km
           {onAssign && (

--- a/FleetFlow/src/pages/WorkforceCoordinatorPage.tsx
+++ b/FleetFlow/src/pages/WorkforceCoordinatorPage.tsx
@@ -20,7 +20,12 @@ export default function WorkforceCoordinatorPage() {
 
   const rankMutation = useMutation({
     mutationFn: (request: Request) =>
-      rankOperators(request.start_date, request.end_date),
+      rankOperators(
+        request.start_date,
+        request.end_date,
+        request.site_lat,
+        request.site_lon,
+      ),
     onSuccess: (data, variables) => {
       setMatches((prev) => ({ ...prev, [variables.id]: data }))
     },
@@ -113,7 +118,7 @@ export default function WorkforceCoordinatorPage() {
                 operators={matches[r.id].map((m) => ({
                   id: m.operator_id,
                   name: m.operator_name,
-                  distance_km: null,
+                  distance_km: m.distance_km,
                 }))}
                 onAssign={(opId) => handleAssign(r, String(opId))}
               />

--- a/FleetFlow/src/types.ts
+++ b/FleetFlow/src/types.ts
@@ -43,6 +43,8 @@ export const RequestSchema = z.object({
   end_date: z.coerce.date(),
   quantity: z.number(),
   operated: z.boolean(),
+  site_lat: z.number(),
+  site_lon: z.number(),
 })
 export type Request = z.infer<typeof RequestSchema>
 
@@ -62,6 +64,7 @@ export type AssetScore = z.infer<typeof AssetScoreSchema>
 export const OperatorMatchSchema = z.object({
   operator_id: z.string(),
   operator_name: z.string(),
+  distance_km: z.number().nullable(),
 })
 export type OperatorMatch = z.infer<typeof OperatorMatchSchema>
 


### PR DESCRIPTION
## Summary
- compute operator distance in rpc_rank_operators
- expose distance_km through queries and types
- sort and display operator matches by distance

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a48beda2ec832ca66a428033dcb284