### PR TITLE
Use Monday week starts and expose canonical week RPC

### DIFF
--- a/FleetFlow/src/api/queries.ts
+++ b/FleetFlow/src/api/queries.ts
@@ -7,6 +7,7 @@ import {
   AllocationSchema,
   RequestSchema,
   WeeklyGroupUtilizationSchema,
+  WeekStartSchema,
   AssetScoreSchema,
   OperatorMatchSchema,
   OperatorAssignmentSchema,
@@ -16,6 +17,7 @@ import {
   type Allocation,
   type Request,
   type WeeklyGroupUtilization,
+  type WeekStart,
   type AssetScore,
   type OperatorMatch,
   type OperatorAssignment,
@@ -115,6 +117,29 @@ export const useWeeklyGroupUtilizationQuery = () =>
   useQuery<WeeklyGroupUtilization[], Error>({
     queryKey: ['weekly-group-utilization'],
     queryFn: fetchWeeklyGroupUtilization,
+  })
+
+export const fetchWeekStarts = async (
+  startDate: Date,
+  endDate: Date,
+): Promise<WeekStart[]> => {
+  const { data, error } = await supabase.rpc('rpc_week_starts', {
+    start_date: startDate.toISOString().slice(0, 10),
+    end_date: endDate.toISOString().slice(0, 10),
+  })
+  if (error) {
+    throw new Error(error.message)
+  }
+  return WeekStartSchema.array().parse(data ?? [])
+}
+
+export const useWeekStartsQuery = (
+  startDate: Date,
+  endDate: Date,
+) =>
+  useQuery<WeekStart[], Error>({
+    queryKey: ['week-starts', startDate, endDate],
+    queryFn: () => fetchWeekStarts(startDate, endDate),
   })
 
 export const rankOperators = async (

--- a/FleetFlow/src/lib/weeks.test.ts
+++ b/FleetFlow/src/lib/weeks.test.ts
@@ -2,9 +2,17 @@ import { describe, expect, it } from 'vitest'
 import { getWeekDays } from './weeks'
 
 describe('getWeekDays', () => {
-  it('returns 7 days starting on Sunday', () => {
+  it('returns 7 days starting on Monday', () => {
     const days = getWeekDays(new Date('2024-02-14'))
     expect(days).toHaveLength(7)
-    expect(days[0].getDay()).toBe(0)
+    expect(days[0].getDay()).toBe(1)
+  })
+
+  it('handles fiscal week boundary around April 1', () => {
+    const endOfFiscal = getWeekDays(new Date('2024-03-31'))
+    expect(endOfFiscal[0].toISOString().slice(0, 10)).toBe('2024-03-25')
+
+    const startOfFiscal = getWeekDays(new Date('2024-04-01'))
+    expect(startOfFiscal[0].toISOString().slice(0, 10)).toBe('2024-04-01')
   })
 })

--- a/FleetFlow/src/lib/weeks.ts
+++ b/FleetFlow/src/lib/weeks.ts
@@ -1,6 +1,7 @@
 export const getWeekDays = (date = new Date()): Date[] => {
   const start = new Date(date)
-  start.setDate(start.getDate() - start.getDay())
+  const day = (start.getDay() + 6) % 7 // Monday as 0
+  start.setDate(start.getDate() - day)
   return Array.from({ length: 7 }, (_, i) => {
     const d = new Date(start)
     d.setDate(start.getDate() + i)

--- a/FleetFlow/src/pages/__tests__/WorkforceCoordinatorPage.test.tsx
+++ b/FleetFlow/src/pages/__tests__/WorkforceCoordinatorPage.test.tsx
@@ -41,7 +41,6 @@ vi.mock('../../utils/validation', () => ({
 }))
 
 import WorkforceCoordinatorPage from '../WorkforceCoordinatorPage'
-import { supabase } from '../../lib/supabase'
 import { rankOperators } from '../../api/queries'
 
 afterEach(() => cleanup())

--- a/FleetFlow/src/types.ts
+++ b/FleetFlow/src/types.ts
@@ -55,6 +55,11 @@ export const WeeklyGroupUtilizationSchema = z.object({
 })
 export type WeeklyGroupUtilization = z.infer<typeof WeeklyGroupUtilizationSchema>
 
+export const WeekStartSchema = z.object({
+  week_start: z.coerce.date(),
+})
+export type WeekStart = z.infer<typeof WeekStartSchema>
+
 export const AssetScoreSchema = z.object({
   asset_code: z.string(),
   score: z.number(),

--- a/FleetFlow/supabase/rpc_week_starts.sql
+++ b/FleetFlow/supabase/rpc_week_starts.sql
@@ -1,0 +1,21 @@
+-- Function: rpc_week_starts
+-- Description: Returns canonical week start dates (Mondays) between two dates.
+-- Parameters:
+--   start_date date - first date in range
+--   end_date date - last date in range
+-- Returns: table(week_start date)
+create or replace function rpc_week_starts(
+  start_date date,
+  end_date date
+)
+returns table (
+  week_start date
+)
+language sql
+as $$
+  select generate_series(
+    date_trunc('week', start_date),
+    date_trunc('week', end_date),
+    interval '1 week'
+  )::date as week_start;
+$$;


### PR DESCRIPTION
## Summary
- compute week starts from Monday instead of using `Date.getDay`
- add fiscal boundary coverage in week tests
- add Supabase RPC and client helpers for canonical week start dates

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a492e8e5a8832cb71883d8cf3a6883