### PR TITLE
ci: export Vite Supabase env vars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-      SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+      VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
     steps:
       - uses: actions/checkout@v4
 

--- a/FleetFlow/src/pages/__tests__/WorkforceCoordinatorPage.test.tsx
+++ b/FleetFlow/src/pages/__tests__/WorkforceCoordinatorPage.test.tsx
@@ -41,7 +41,6 @@ vi.mock('../../utils/validation', () => ({
 }))
 
 import WorkforceCoordinatorPage from '../WorkforceCoordinatorPage'
-import { supabase } from '../../lib/supabase'
 import { rankOperators } from '../../api/queries'
 
 afterEach(() => cleanup())


### PR DESCRIPTION
## Summary
- expose VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY in CI workflow
- remove unused Supabase import in WorkforceCoordinatorPage test

## Testing
- `python3 -m pre_commit run --files .github/workflows/ci.yml FleetFlow/src/pages/__tests__/WorkforceCoordinatorPage.test.tsx`
- `npm run lint`
- `npm test --if-present`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a4932fa5d0832c964b7255b277fc88