### PR TITLE
feat: enforce allocation overlap constraint

### DIFF
--- a/FleetFlow/README.md
+++ b/FleetFlow/README.md
@@ -51,7 +51,7 @@ Key tables: `equipment_groups`, `group_substitutions`, `assets`, `sites`, `contr
 
 **Safety constraints**
 
-* `allocations_no_overlap` (GiST EXCLUDE): no double‑booking an **asset**.
+* `allocations_no_overlap` (GiST EXCLUDE on `asset_id` + `daterange(start_date, end_date, '[]')`): no double‑booking an **asset**.
 * `operator_no_overlap` (GiST EXCLUDE): no double‑booking an **operator**.
 
 **Views**
@@ -136,6 +136,7 @@ Open [http://localhost:5173](http://localhost:5173) (or the port Vite shows). Th
 * `rpc_score_assets(group_id, start_date, end_date, site_lat, site_lon)` → returns ranked candidates
 * `rpc_allocate_best_asset(request_id, group_id, start_date, end_date, site_lat, site_lon)` → inserts allocation or raises `NO_INTERNAL_ASSET_AVAILABLE`
 * `rpc_rank_operators(start_date, end_date)` → lists available operators ordered by name, excluding those with overlapping assignments or unavailability
+* `rpc_reassign_allocation(allocation_id)` → moves an allocation forward one day and errors if it overlaps
 
 ## Deployment
 

--- a/FleetFlow/src/api/queries.test.ts
+++ b/FleetFlow/src/api/queries.test.ts
@@ -102,5 +102,10 @@ describe('reassignAllocation', () => {
     })
     expect(result).toEqual({ id: 'e1', title: 'Ev', date: new Date('2024-01-01') })
   })
+
+  it('throws on overlap error', async () => {
+    rpcMock.mockResolvedValue({ data: null, error: { message: 'ALLOCATION_OVERLAP' } })
+    await expect(reassignAllocation('alloc1')).rejects.toThrow('ALLOCATION_OVERLAP')
+  })
 })
 

--- a/FleetFlow/src/supabase/constraints.test.ts
+++ b/FleetFlow/src/supabase/constraints.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const sql = readFileSync(resolve(__dirname, '../../supabase/constraints.sql'), 'utf8')
+
+describe('Constraints', () => {
+  it('prevents overlapping allocations', () => {
+    expect(sql).toContain('constraint allocations_no_overlap')
+    expect(sql).toContain("daterange(start_date, end_date, '[]')")
+  })
+})

--- a/FleetFlow/supabase/constraints.sql
+++ b/FleetFlow/supabase/constraints.sql
@@ -1,0 +1,11 @@
+-- Constraints for preventing overlaps
+
+-- allocations_no_overlap: prevent double-booking an asset
+create extension if not exists btree_gist;
+
+alter table allocations
+  add constraint allocations_no_overlap
+  exclude using gist (
+    asset_id with =,
+    daterange(start_date, end_date, '[]') with &&
+  );

--- a/FleetFlow/supabase/rpc_reassign_allocation.sql
+++ b/FleetFlow/supabase/rpc_reassign_allocation.sql
@@ -7,11 +7,17 @@ create or replace function rpc_reassign_allocation(
   allocation_id uuid
 )
 returns setof allocations
-language sql
+language plpgsql
 as $$
-  update allocations
-     set start_date = start_date + interval '1 day',
-         end_date   = end_date + interval '1 day'
-   where id = allocation_id
-  returning *;
+begin
+  return query
+    update allocations
+       set start_date = start_date + interval '1 day',
+           end_date   = end_date + interval '1 day'
+     where id = allocation_id
+    returning *;
+exception
+  when exclusion_violation then
+    raise exception 'ALLOCATION_OVERLAP';
+end;
 $$;


### PR DESCRIPTION
## Summary
- add GiST exclusion constraint to prevent overlapping allocations
- surface overlap conflicts from `rpc_reassign_allocation`
- document and test allocation overlap handling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a4959223b0832cbb2041beff841771