### PR TITLE
chore: restrict base table reads

### DIFF
--- a/FleetFlow/supabase/policies.sql
+++ b/FleetFlow/supabase/policies.sql
@@ -2,6 +2,12 @@
 
 -- external_hires: only plant coordinators may modify
 alter table external_hires enable row level security;
+revoke select on external_hires from public;
+
+create policy external_hires_select_plant on external_hires
+for select
+to authenticated
+using (auth.jwt() ->> 'role' = 'plant_coordinator');
 
 create policy external_hires_insert_plant on external_hires
 for insert
@@ -21,6 +27,12 @@ using (auth.jwt() ->> 'role' = 'plant_coordinator');
 
 -- allocations: only plant coordinators may modify
 alter table allocations enable row level security;
+revoke select on allocations from public;
+
+create policy allocations_select_plant on allocations
+for select
+to authenticated
+using (auth.jwt() ->> 'role' = 'plant_coordinator');
 
 create policy allocations_insert_plant on allocations
 for insert
@@ -40,6 +52,12 @@ using (auth.jwt() ->> 'role' = 'plant_coordinator');
 
 -- operator_assignments: only workforce coordinators may modify
 alter table operator_assignments enable row level security;
+revoke select on operator_assignments from public;
+
+create policy operator_assignments_select_workforce on operator_assignments
+for select
+to authenticated
+using (auth.jwt() ->> 'role' = 'workforce_coordinator');
 
 create policy operator_assignments_insert_workforce on operator_assignments
 for insert
@@ -56,3 +74,16 @@ create policy operator_assignments_delete_workforce on operator_assignments
 for delete
 to authenticated
 using (auth.jwt() ->> 'role' = 'workforce_coordinator');
+
+-- RLS-protected read-only views
+create or replace view vw_external_hires as
+select * from external_hires;
+grant select on vw_external_hires to authenticated;
+
+create or replace view vw_allocations as
+select * from allocations;
+grant select on vw_allocations to authenticated;
+
+create or replace view vw_operator_assignments as
+select * from operator_assignments;
+grant select on vw_operator_assignments to authenticated;

--- a/FleetFlow/supabase/policies.test.ts
+++ b/FleetFlow/supabase/policies.test.ts
@@ -1,0 +1,49 @@
+import { spawnSync } from 'node:child_process';
+import { describe, it, beforeAll, expect } from 'vitest';
+import { resolve } from 'node:path';
+
+const run = (cmd: string, args: string[], opts = {}) => {
+  const result = spawnSync(cmd, args, { encoding: 'utf8', ...opts });
+  if (result.status !== 0) {
+    throw new Error(result.stderr || result.stdout);
+  }
+  return result;
+};
+
+beforeAll(() => {
+  // ensure postgres is running
+  spawnSync('pg_ctlcluster', ['16', 'main', 'start']);
+
+  // recreate test database
+  run('sudo', ['-u', 'postgres', 'psql', '-c', 'DROP DATABASE IF EXISTS fleetflow_test;']);
+  run('sudo', ['-u', 'postgres', 'psql', '-c', 'CREATE DATABASE fleetflow_test;']);
+
+  // minimal table structure
+  run('sudo', ['-u', 'postgres', 'psql', '-d', 'fleetflow_test', '-c', `
+    CREATE TABLE external_hires(id serial primary key);
+    CREATE TABLE allocations(id serial primary key);
+    CREATE TABLE operator_assignments(id serial primary key);
+    INSERT INTO external_hires DEFAULT VALUES;
+  `]);
+
+  // apply policies
+  run('sudo', ['-u', 'postgres', 'psql', '-d', 'fleetflow_test', '-f', resolve(__dirname, 'policies.sql')]);
+
+  // create unauthorized role
+  run('sudo', ['-u', 'postgres', 'psql', '-c', `
+    DROP ROLE IF EXISTS authenticated;
+    CREATE ROLE authenticated LOGIN PASSWORD 'secret';
+    GRANT CONNECT ON DATABASE fleetflow_test TO authenticated;
+  `]);
+});
+
+describe('RLS policies', () => {
+  it('prevents direct table reads for unauthorised roles', () => {
+    const result = spawnSync('psql', ['-h', 'localhost', '-U', 'authenticated', '-d', 'fleetflow_test', '-c', 'select * from external_hires;'], {
+      env: { ...process.env, PGPASSWORD: 'secret' },
+      encoding: 'utf8'
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('permission denied');
+  });
+});


### PR DESCRIPTION
## Summary
- revoke default SELECT on sensitive tables and add RLS read policies
- expose read-only views for coordinator tables
- test that unauthorised roles cannot query base tables

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a4959a02ec832ca225e17be4cbadfd