### PR TITLE
Use server-stored roles for authorization

### DIFF
--- a/FleetFlow/README.md
+++ b/FleetFlow/README.md
@@ -16,6 +16,7 @@ FleetFlow is a role‑based civil engineering **fleet & operated plant scheduler
 * [Running locally](#running-locally)
 * [Calendar UX](#calendar-ux)
 * [Role workflows](#role-workflows)
+* [Authorization](#authorization)
 * [APIs (DB views & RPCs)](#apis-db-views--rpcs)
 * [Deployment](#deployment)
 * [Roadmap](#roadmap)
@@ -122,6 +123,13 @@ Open [http://localhost:5173](http://localhost:5173) (or the port Vite shows). Th
 **Workforce Coordinators**
 
 * For operated requests, assign `operators` who have required tickets and no overlaps
+
+## Authorization
+
+Roles live in the `profiles.role` column and are surfaced to clients through a custom JWT
+claim. The frontend's route guards use this value for a better UX, but these checks are
+advisory—Postgres **row level security** is the source of truth and enforces all
+authorization.
 
 ## APIs (DB views & RPCs)
 

--- a/FleetFlow/src/components/AuthProvider.tsx
+++ b/FleetFlow/src/components/AuthProvider.tsx
@@ -5,11 +5,18 @@ import { AuthContext } from './auth-context'
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null)
+  const [role, setRole] = useState<string | null>(null)
 
   useEffect(() => {
     const fetchUser = async () => {
       const { data } = await supabase.auth.getUser()
       setUser(data.user)
+      if (data.user) {
+        const { data: roleData } = await supabase.rpc('get_role')
+        setRole(roleData)
+      } else {
+        setRole(null)
+      }
     }
     fetchUser()
     const {
@@ -22,6 +29,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   }, [])
 
-  return <AuthContext.Provider value={{ user }}>{children}</AuthContext.Provider>
+  return <AuthContext.Provider value={{ user, role }}>{children}</AuthContext.Provider>
 }
 

--- a/FleetFlow/src/components/ProtectedRoute.test.tsx
+++ b/FleetFlow/src/components/ProtectedRoute.test.tsx
@@ -9,7 +9,7 @@ import type { User } from '@supabase/supabase-js'
 describe('ProtectedRoute', () => {
   it('redirects to login when user is not authenticated', () => {
     render(
-      <AuthContext.Provider value={{ user: null }}>
+      <AuthContext.Provider value={{ user: null, role: null }}>
         <MemoryRouter initialEntries={['/protected']}>
           <Routes>
             <Route path='/login' element={<div>Login Page</div>} />
@@ -32,7 +32,7 @@ describe('ProtectedRoute', () => {
   it('renders children when role matches', () => {
     render(
       <AuthContext.Provider
-        value={{ user: { user_metadata: { role: 'plant_coordinator' } } as unknown as User }}
+        value={{ user: {} as User, role: 'plant_coordinator' }}
       >
         <MemoryRouter initialEntries={['/protected']}>
           <Routes>
@@ -55,7 +55,7 @@ describe('ProtectedRoute', () => {
   it('redirects to home when role does not match', () => {
     render(
       <AuthContext.Provider
-        value={{ user: { user_metadata: { role: 'driver' } } as unknown as User }}
+        value={{ user: {} as User, role: 'driver' }}
       >
         <MemoryRouter initialEntries={['/protected']}>
           <Routes>

--- a/FleetFlow/src/components/ProtectedRoute.tsx
+++ b/FleetFlow/src/components/ProtectedRoute.tsx
@@ -9,14 +9,13 @@ export default function ProtectedRoute({
   children: ReactNode
   roles: string[]
 }) {
-  const { user } = useAuth()
+  const { user, role } = useAuth()
 
   if (!user) {
     return <Navigate to='/login' replace />
   }
 
-  const userRole = (user.user_metadata as { role?: string } | undefined)?.role
-  if (!userRole || !roles.includes(userRole)) {
+  if (!role || !roles.includes(role)) {
     return <Navigate to='/' replace />
   }
 

--- a/FleetFlow/src/components/auth-context.ts
+++ b/FleetFlow/src/components/auth-context.ts
@@ -3,9 +3,10 @@ import type { User } from '@supabase/supabase-js'
 
 export interface AuthContextValue {
   user: User | null
+  role: string | null
 }
 
-export const AuthContext = createContext<AuthContextValue>({ user: null })
+export const AuthContext = createContext<AuthContextValue>({ user: null, role: null })
 
 export function useAuth() {
   return useContext(AuthContext)

--- a/FleetFlow/supabase/roles.sql
+++ b/FleetFlow/supabase/roles.sql
@@ -1,0 +1,29 @@
+-- Roles stored in profiles and surfaced via JWT + RPC
+
+-- Add role column if it doesn't exist
+alter table profiles
+  add column if not exists role text
+    check (role in ('contract_manager','plant_coordinator','workforce_coordinator'))
+    default 'contract_manager';
+
+-- Expose role in JWT so policies can rely on auth.jwt()->>'role'
+create or replace function auth.jwt_custom_claims()
+returns jsonb
+language sql
+stable
+as $$
+  select json_build_object(
+    'role', (select role from public.profiles where id = auth.uid())
+  );
+$$;
+
+-- RPC for clients to fetch their server-defined role
+create or replace function rpc_get_role()
+returns text
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  select role from profiles where id = auth.uid();
+$$;


### PR DESCRIPTION
## Summary
- add `profiles.role` column and surface it via jwt claim + `rpc_get_role`
- load server role in `AuthProvider` and consume it from `ProtectedRoute`
- clarify in docs that frontend role checks are advisory; RLS enforces access

## Testing
- `pre-commit run --files FleetFlow/src/components/auth-context.ts FleetFlow/src/components/AuthProvider.tsx FleetFlow/src/components/ProtectedRoute.tsx FleetFlow/src/components/ProtectedRoute.test.tsx FleetFlow/README.md FleetFlow/supabase/roles.sql`
- `npm --prefix FleetFlow test`


------
https://chatgpt.com/codex/tasks/task_b_68a497a2a910832c86fbc634b2dbf621