### PR TITLE
Enhance RLS and auth handling

### DIFF
--- a/FleetFlow/src/api/queries.ts
+++ b/FleetFlow/src/api/queries.ts
@@ -66,7 +66,7 @@ export const useEquipmentGroupsQuery = () =>
   })
 
 export const fetchAllocations = async (): Promise<Allocation[]> => {
-  const { data, error } = await supabase.from('allocations').select('*')
+  const { data, error } = await supabase.from('vw_allocations').select('*')
   if (error) {
     throw new Error(error.message)
   }

--- a/FleetFlow/src/components/AuthProvider.tsx
+++ b/FleetFlow/src/components/AuthProvider.tsx
@@ -6,9 +6,11 @@ import { AuthContext } from './auth-context'
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null)
   const [role, setRole] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     const fetchUser = async () => {
+      setLoading(true)
       const { data } = await supabase.auth.getUser()
       setUser(data.user)
       if (data.user) {
@@ -17,6 +19,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       } else {
         setRole(null)
       }
+      setLoading(false)
     }
     fetchUser()
     const {
@@ -29,6 +32,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   }, [])
 
-  return <AuthContext.Provider value={{ user, role }}>{children}</AuthContext.Provider>
+  return (
+    <AuthContext.Provider value={{ user, role, loading }}>
+      {children}
+    </AuthContext.Provider>
+  )
 }
 

--- a/FleetFlow/src/components/ProtectedRoute.test.tsx
+++ b/FleetFlow/src/components/ProtectedRoute.test.tsx
@@ -9,7 +9,7 @@ import type { User } from '@supabase/supabase-js'
 describe('ProtectedRoute', () => {
   it('redirects to login when user is not authenticated', () => {
     render(
-      <AuthContext.Provider value={{ user: null, role: null }}>
+      <AuthContext.Provider value={{ user: null, role: null, loading: false }}>
         <MemoryRouter initialEntries={['/protected']}>
           <Routes>
             <Route path='/login' element={<div>Login Page</div>} />
@@ -32,7 +32,7 @@ describe('ProtectedRoute', () => {
   it('renders children when role matches', () => {
     render(
       <AuthContext.Provider
-        value={{ user: {} as User, role: 'plant_coordinator' }}
+        value={{ user: {} as User, role: 'plant_coordinator', loading: false }}
       >
         <MemoryRouter initialEntries={['/protected']}>
           <Routes>
@@ -55,7 +55,7 @@ describe('ProtectedRoute', () => {
   it('redirects to home when role does not match', () => {
     render(
       <AuthContext.Provider
-        value={{ user: {} as User, role: 'driver' }}
+        value={{ user: {} as User, role: 'driver', loading: false }}
       >
         <MemoryRouter initialEntries={['/protected']}>
           <Routes>

--- a/FleetFlow/src/components/ProtectedRoute.tsx
+++ b/FleetFlow/src/components/ProtectedRoute.tsx
@@ -7,15 +7,19 @@ export default function ProtectedRoute({
   roles,
 }: {
   children: ReactNode
-  roles: string[]
+  roles?: string[]
 }) {
-  const { user, role } = useAuth()
+  const { user, role, loading } = useAuth()
+
+  if (loading) {
+    return <div>Loading...</div>
+  }
 
   if (!user) {
     return <Navigate to='/login' replace />
   }
 
-  if (!role || !roles.includes(role)) {
+  if (roles && roles.length > 0 && (!role || !roles.includes(role))) {
     return <Navigate to='/' replace />
   }
 

--- a/FleetFlow/src/components/auth-context.ts
+++ b/FleetFlow/src/components/auth-context.ts
@@ -4,9 +4,14 @@ import type { User } from '@supabase/supabase-js'
 export interface AuthContextValue {
   user: User | null
   role: string | null
+  loading: boolean
 }
 
-export const AuthContext = createContext<AuthContextValue>({ user: null, role: null })
+export const AuthContext = createContext<AuthContextValue>({
+  user: null,
+  role: null,
+  loading: true,
+})
 
 export function useAuth() {
   return useContext(AuthContext)

--- a/FleetFlow/src/supabase/policies.test.ts
+++ b/FleetFlow/src/supabase/policies.test.ts
@@ -7,16 +7,22 @@ const sql = readFileSync(resolve(__dirname, '../../supabase/policies.sql'), 'utf
 describe('RLS policies', () => {
   it('restricts external_hires to plant coordinators', () => {
     expect(sql).toContain("alter table external_hires enable row level security")
-    expect(sql).toContain("auth.jwt() ->> 'role' = 'plant_coordinator'")
+    expect(sql).toContain(
+      "auth.jwt() ->> 'role' in ('plant_coordinator', 'admin')",
+    )
   })
 
   it('restricts allocations to plant coordinators', () => {
     expect(sql).toContain("alter table allocations enable row level security")
-    expect(sql).toContain("auth.jwt() ->> 'role' = 'plant_coordinator'")
+    expect(sql).toContain(
+      "auth.jwt() ->> 'role' in ('plant_coordinator', 'admin')",
+    )
   })
 
   it('restricts operator_assignments to workforce coordinators', () => {
     expect(sql).toContain("alter table operator_assignments enable row level security")
-    expect(sql).toContain("auth.jwt() ->> 'role' = 'workforce_coordinator'")
+    expect(sql).toContain(
+      "auth.jwt() ->> 'role' in ('workforce_coordinator', 'admin')",
+    )
   })
 })

--- a/FleetFlow/supabase/policies.sql
+++ b/FleetFlow/supabase/policies.sql
@@ -7,23 +7,23 @@ revoke select on external_hires from public;
 create policy external_hires_select_plant on external_hires
 for select
 to authenticated
-using (auth.jwt() ->> 'role' = 'plant_coordinator');
+using (auth.jwt() ->> 'role' in ('plant_coordinator', 'admin'));
 
 create policy external_hires_insert_plant on external_hires
 for insert
 to authenticated
-with check (auth.jwt() ->> 'role' = 'plant_coordinator');
+with check (auth.jwt() ->> 'role' in ('plant_coordinator', 'admin'));
 
 create policy external_hires_update_plant on external_hires
 for update
 to authenticated
-using (auth.jwt() ->> 'role' = 'plant_coordinator')
-with check (auth.jwt() ->> 'role' = 'plant_coordinator');
+using (auth.jwt() ->> 'role' in ('plant_coordinator', 'admin'))
+with check (auth.jwt() ->> 'role' in ('plant_coordinator', 'admin'));
 
 create policy external_hires_delete_plant on external_hires
 for delete
 to authenticated
-using (auth.jwt() ->> 'role' = 'plant_coordinator');
+using (auth.jwt() ->> 'role' in ('plant_coordinator', 'admin'));
 
 -- allocations: only plant coordinators may modify
 alter table allocations enable row level security;
@@ -32,23 +32,23 @@ revoke select on allocations from public;
 create policy allocations_select_plant on allocations
 for select
 to authenticated
-using (auth.jwt() ->> 'role' = 'plant_coordinator');
+using (auth.jwt() ->> 'role' in ('plant_coordinator', 'admin'));
 
 create policy allocations_insert_plant on allocations
 for insert
 to authenticated
-with check (auth.jwt() ->> 'role' = 'plant_coordinator');
+with check (auth.jwt() ->> 'role' in ('plant_coordinator', 'admin'));
 
 create policy allocations_update_plant on allocations
 for update
 to authenticated
-using (auth.jwt() ->> 'role' = 'plant_coordinator')
-with check (auth.jwt() ->> 'role' = 'plant_coordinator');
+using (auth.jwt() ->> 'role' in ('plant_coordinator', 'admin'))
+with check (auth.jwt() ->> 'role' in ('plant_coordinator', 'admin'));
 
 create policy allocations_delete_plant on allocations
 for delete
 to authenticated
-using (auth.jwt() ->> 'role' = 'plant_coordinator');
+using (auth.jwt() ->> 'role' in ('plant_coordinator', 'admin'));
 
 -- operator_assignments: only workforce coordinators may modify
 alter table operator_assignments enable row level security;
@@ -57,23 +57,72 @@ revoke select on operator_assignments from public;
 create policy operator_assignments_select_workforce on operator_assignments
 for select
 to authenticated
-using (auth.jwt() ->> 'role' = 'workforce_coordinator');
+using (auth.jwt() ->> 'role' in ('workforce_coordinator', 'admin'));
 
 create policy operator_assignments_insert_workforce on operator_assignments
 for insert
 to authenticated
-with check (auth.jwt() ->> 'role' = 'workforce_coordinator');
+with check (
+  auth.jwt() ->> 'role' in ('workforce_coordinator', 'admin')
+);
 
 create policy operator_assignments_update_workforce on operator_assignments
 for update
 to authenticated
-using (auth.jwt() ->> 'role' = 'workforce_coordinator')
-with check (auth.jwt() ->> 'role' = 'workforce_coordinator');
+using (auth.jwt() ->> 'role' in ('workforce_coordinator', 'admin'))
+with check (
+  auth.jwt() ->> 'role' in ('workforce_coordinator', 'admin')
+);
 
 create policy operator_assignments_delete_workforce on operator_assignments
 for delete
 to authenticated
-using (auth.jwt() ->> 'role' = 'workforce_coordinator');
+using (auth.jwt() ->> 'role' in ('workforce_coordinator', 'admin'));
+
+-- hire_requests: coordinators may read
+alter table hire_requests enable row level security;
+revoke select on hire_requests from public;
+
+create policy hire_requests_select_coordinators on hire_requests
+for select
+to authenticated
+using (
+  auth.jwt() ->> 'role' in (
+    'plant_coordinator',
+    'workforce_coordinator',
+    'admin'
+  )
+);
+
+-- calendar_events: coordinators may read
+alter table calendar_events enable row level security;
+revoke select on calendar_events from public;
+
+create policy calendar_events_select_coordinators on calendar_events
+for select
+to authenticated
+using (
+  auth.jwt() ->> 'role' in (
+    'plant_coordinator',
+    'workforce_coordinator',
+    'admin'
+  )
+);
+
+-- equipment_groups: coordinators may read
+alter table equipment_groups enable row level security;
+revoke select on equipment_groups from public;
+
+create policy equipment_groups_select_coordinators on equipment_groups
+for select
+to authenticated
+using (
+  auth.jwt() ->> 'role' in (
+    'plant_coordinator',
+    'workforce_coordinator',
+    'admin'
+  )
+);
 
 -- RLS-protected read-only views
 create or replace view vw_external_hires as


### PR DESCRIPTION
## Summary
- allow admin access across coordinator RLS policies and add read guards for core tables
- extend auth context and provider with loading state
- tighten protected routes and use RLS view for allocations

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a49a27f058832ca54fb4c5cd6ad67c