### PR TITLE
Allow allocation via group substitutions

### DIFF
--- a/FleetFlow/src/utils/validation.test.ts
+++ b/FleetFlow/src/utils/validation.test.ts
@@ -16,21 +16,23 @@ describe('validateExternalHire', () => {
     ;(supabase.from as Mock).mockReset()
   })
 
-  it('throws when substitution exists', async () => {
+  it('returns available substitutions', async () => {
     const eq = vi.fn().mockResolvedValue({
       data: [{ group_id: '1', substitute_group_id: '2' }],
       error: null,
     })
     const select = vi.fn(() => ({ eq }))
     ;(supabase.from as Mock).mockReturnValue({ select })
-    await expect(validateExternalHire('1')).rejects.toThrow('SUBSTITUTION_AVAILABLE')
+    await expect(validateExternalHire('1')).resolves.toEqual([
+      { group_id: '1', substitute_group_id: '2' },
+    ])
   })
 
-  it('passes when no substitution', async () => {
+  it('returns empty array when no substitution', async () => {
     const eq = vi.fn().mockResolvedValue({ data: [], error: null })
     const select = vi.fn(() => ({ eq }))
     ;(supabase.from as Mock).mockReturnValue({ select })
-    await expect(validateExternalHire('1')).resolves.toBeUndefined()
+    await expect(validateExternalHire('1')).resolves.toEqual([])
   })
 })
 

--- a/FleetFlow/src/utils/validation.ts
+++ b/FleetFlow/src/utils/validation.ts
@@ -3,9 +3,12 @@ import {
   GroupSubstitutionSchema,
   GroupRequiredTicketSchema,
   OperatorTicketSchema,
+  type GroupSubstitution,
 } from '../types'
 
-export async function validateExternalHire(groupId: string): Promise<void> {
+export async function validateExternalHire(
+  groupId: string,
+): Promise<GroupSubstitution[]> {
   const { data, error } = await supabase
     .from('group_substitutions')
     .select('*')
@@ -13,10 +16,7 @@ export async function validateExternalHire(groupId: string): Promise<void> {
   if (error) {
     throw new Error(error.message)
   }
-  const substitutions = GroupSubstitutionSchema.array().parse(data ?? [])
-  if (substitutions.length > 0) {
-    throw new Error('SUBSTITUTION_AVAILABLE')
-  }
+  return GroupSubstitutionSchema.array().parse(data ?? [])
 }
 
 export async function validateOperatorAssignment(


### PR DESCRIPTION
## Summary
- return available group substitutions instead of throwing
- prompt for substitution groups and retry allocation before creating external hires
- test allocation substitution path

## Testing
- `npm test` *(fails: sudo: unknown user postgres)*

------
https://chatgpt.com/codex/tasks/task_b_68a49a329a00832c8bfa41891546823b