### PR TITLE
Expand API and routing test coverage

### DIFF
--- a/FleetFlow/src/api/queries.test.ts
+++ b/FleetFlow/src/api/queries.test.ts
@@ -14,6 +14,20 @@ import { supabase } from '../lib/supabase'
 import {
   useExampleQuery,
   fetchExample,
+  useEventsQuery,
+  fetchEvents,
+  useEquipmentGroupsQuery,
+  fetchEquipmentGroups,
+  useAllocationsQuery,
+  fetchAllocations,
+  useRequestsQuery,
+  fetchRequests,
+  useWeeklyGroupUtilizationQuery,
+  fetchWeeklyGroupUtilization,
+  useWeekStartsQuery,
+  fetchWeekStarts,
+  useOperatorAssignmentsQuery,
+  fetchOperatorAssignments,
   scoreAssets,
   rankOperators,
   offHireAllocation,
@@ -32,6 +46,96 @@ describe('useExampleQuery', () => {
       queryFn: fetchExample,
     })
     expect(result).toBe(fakeResult)
+  })
+})
+
+describe('other query hooks', () => {
+  beforeEach(() => {
+    ;(useQuery as Mock).mockReset()
+    rpcMock.mockReset()
+  })
+
+  it('uses correct key for events', () => {
+    const fake = { data: [] }
+    ;(useQuery as Mock).mockReturnValue(fake)
+    const result = useEventsQuery()
+    expect(useQuery).toHaveBeenCalledWith({
+      queryKey: ['events'],
+      queryFn: fetchEvents,
+    })
+    expect(result).toBe(fake)
+  })
+
+  it('uses correct key for equipment groups', () => {
+    const fake = { data: [] }
+    ;(useQuery as Mock).mockReturnValue(fake)
+    const result = useEquipmentGroupsQuery()
+    expect(useQuery).toHaveBeenCalledWith({
+      queryKey: ['equipment-groups'],
+      queryFn: fetchEquipmentGroups,
+    })
+    expect(result).toBe(fake)
+  })
+
+  it('uses correct key for allocations', () => {
+    const fake = { data: [] }
+    ;(useQuery as Mock).mockReturnValue(fake)
+    const result = useAllocationsQuery()
+    expect(useQuery).toHaveBeenCalledWith({
+      queryKey: ['allocations'],
+      queryFn: fetchAllocations,
+    })
+    expect(result).toBe(fake)
+  })
+
+  it('uses correct key for requests', () => {
+    const fake = { data: [] }
+    ;(useQuery as Mock).mockReturnValue(fake)
+    const result = useRequestsQuery()
+    expect(useQuery).toHaveBeenCalledWith({
+      queryKey: ['requests'],
+      queryFn: fetchRequests,
+    })
+    expect(result).toBe(fake)
+  })
+
+  it('uses correct key for utilization', () => {
+    const fake = { data: [] }
+    ;(useQuery as Mock).mockReturnValue(fake)
+    const result = useWeeklyGroupUtilizationQuery()
+    expect(useQuery).toHaveBeenCalledWith({
+      queryKey: ['weekly-group-utilization'],
+      queryFn: fetchWeeklyGroupUtilization,
+    })
+    expect(result).toBe(fake)
+  })
+
+  it('passes dates to week starts query', async () => {
+    const fake = { data: [] }
+    const start = new Date('2024-01-01')
+    const end = new Date('2024-01-07')
+    rpcMock.mockResolvedValue({ data: [], error: null })
+    ;(useQuery as Mock).mockReturnValue(fake)
+    const result = useWeekStartsQuery(start, end)
+    const call = (useQuery as Mock).mock.calls.at(-1)![0]
+    expect(call.queryKey).toEqual(['week-starts', start, end])
+    await call.queryFn()
+    expect(rpcMock).toHaveBeenCalledWith('rpc_week_starts', {
+      start_date: '2024-01-01',
+      end_date: '2024-01-07',
+    })
+    expect(result).toBe(fake)
+  })
+
+  it('uses correct key for operator assignments', () => {
+    const fake = { data: [] }
+    ;(useQuery as Mock).mockReturnValue(fake)
+    const result = useOperatorAssignmentsQuery()
+    expect(useQuery).toHaveBeenCalledWith({
+      queryKey: ['operator-assignments'],
+      queryFn: fetchOperatorAssignments,
+    })
+    expect(result).toBe(fake)
   })
 })
 

--- a/FleetFlow/src/components/ProtectedRoute.test.tsx
+++ b/FleetFlow/src/components/ProtectedRoute.test.tsx
@@ -1,13 +1,15 @@
 /** @vitest-environment jsdom */
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, afterEach } from 'vitest'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
-import { render, screen } from '@testing-library/react'
+import { render, screen, cleanup } from '@testing-library/react'
 import ProtectedRoute from './ProtectedRoute'
 import { AuthContext } from './auth-context'
 import type { User } from '@supabase/supabase-js'
 
 describe('ProtectedRoute', () => {
-  it('redirects to login when user is not authenticated', () => {
+    afterEach(() => cleanup())
+
+    it('redirects to login when user is not authenticated', () => {
     render(
       <AuthContext.Provider value={{ user: null, role: null, loading: false }}>
         <MemoryRouter initialEntries={['/protected']}>
@@ -27,9 +29,9 @@ describe('ProtectedRoute', () => {
     )
 
     expect(screen.getByText('Login Page')).toBeTruthy()
-  })
+    })
 
-  it('renders children when role matches', () => {
+    it('renders children when role matches', () => {
     render(
       <AuthContext.Provider
         value={{ user: {} as User, role: 'plant_coordinator', loading: false }}
@@ -50,9 +52,9 @@ describe('ProtectedRoute', () => {
     )
 
     expect(screen.getByText('Secret')).toBeTruthy()
-  })
+    })
 
-  it('redirects to home when role does not match', () => {
+    it('redirects to home when role does not match', () => {
     render(
       <AuthContext.Provider
         value={{ user: {} as User, role: 'driver', loading: false }}
@@ -74,6 +76,52 @@ describe('ProtectedRoute', () => {
     )
 
     expect(screen.getByText('Home')).toBeTruthy()
+    })
+
+    it('renders loading state when auth is loading', () => {
+      render(
+        <AuthContext.Provider value={{ user: null, role: null, loading: true }}>
+          <MemoryRouter initialEntries={['/protected']}>
+            <Routes>
+              <Route
+                path='/protected'
+                element={
+                  <ProtectedRoute roles={['plant_coordinator']}>
+                    <div>Secret</div>
+                  </ProtectedRoute>
+                }
+              />
+            </Routes>
+          </MemoryRouter>
+        </AuthContext.Provider>,
+      )
+
+      expect(screen.getByText('Loading...')).toBeTruthy()
+    })
+
+    it('allows access when role is among allowed roles', () => {
+      render(
+        <AuthContext.Provider
+          value={{ user: {} as User, role: 'workforce_coordinator', loading: false }}
+        >
+          <MemoryRouter initialEntries={['/protected']}>
+            <Routes>
+              <Route
+                path='/protected'
+                element={
+                  <ProtectedRoute
+                    roles={['plant_coordinator', 'workforce_coordinator']}
+                  >
+                    <div>Secret</div>
+                  </ProtectedRoute>
+                }
+              />
+            </Routes>
+          </MemoryRouter>
+        </AuthContext.Provider>,
+      )
+
+      expect(screen.getByText('Secret')).toBeTruthy()
+    })
   })
-})
 

--- a/FleetFlow/src/pages/__tests__/CalendarPage.test.tsx
+++ b/FleetFlow/src/pages/__tests__/CalendarPage.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import CalendarPage from '../CalendarPage'
+import type { CalendarEvent } from '../../types'
+
+const offHireMock = vi.hoisted(() => vi.fn())
+const reassignMock = vi.hoisted(() => vi.fn())
+
+let events: CalendarEvent[] = [
+  { id: '1', title: 'Event1', date: new Date() },
+]
+
+vi.mock('../../api/queries', () => ({
+  useEventsQuery: () => ({ data: events, isLoading: false, error: null }),
+  useEquipmentGroupsQuery: () => ({ data: [] }),
+  useAllocationsQuery: () => ({ data: [] }),
+  useRequestsQuery: () => ({ data: [] }),
+  useWeeklyGroupUtilizationQuery: () => ({ data: [] }),
+  offHireAllocation: offHireMock,
+  reassignAllocation: reassignMock,
+}))
+
+const renderPage = () => {
+  const client = new QueryClient()
+  return render(
+    <QueryClientProvider client={client}>
+      <CalendarPage />
+    </QueryClientProvider>,
+  )
+}
+
+describe('CalendarPage event actions', () => {
+  beforeEach(() => {
+    events = [{ id: '1', title: 'Event1', date: new Date() }]
+    offHireMock.mockReset()
+    reassignMock.mockReset()
+  })
+  afterEach(() => cleanup())
+
+  it('off-hire removes event', async () => {
+    offHireMock.mockResolvedValueOnce(undefined)
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: 'Event1' }))
+    fireEvent.click(screen.getAllByText('Off-hire').at(-1)!)
+    await waitFor(() => expect(offHireMock).toHaveBeenCalledWith('1'))
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('button', { name: 'Event1' }),
+      ).toBeNull(),
+    )
+  })
+
+  it('reassign updates event title', async () => {
+    reassignMock.mockResolvedValueOnce({
+      id: '1',
+      title: 'Updated',
+      date: new Date(),
+    })
+    renderPage()
+    fireEvent.click(screen.getByRole('button', { name: 'Event1' }))
+    fireEvent.click(screen.getAllByText('Reassign').at(-1)!)
+    await waitFor(() => expect(reassignMock).toHaveBeenCalledWith('1'))
+    await waitFor(() => expect(screen.getByText('Updated')).toBeTruthy())
+  })
+})

--- a/FleetFlow/src/utils/validation.test.ts
+++ b/FleetFlow/src/utils/validation.test.ts
@@ -11,7 +11,7 @@ vi.mock('../lib/supabase', () => {
 import { validateExternalHire, validateOperatorAssignment } from './validation'
 import { supabase } from '../lib/supabase'
 
-describe('validateExternalHire', () => {
+  describe('validateExternalHire', () => {
   beforeEach(() => {
     ;(supabase.from as Mock).mockReset()
   })
@@ -28,15 +28,22 @@ describe('validateExternalHire', () => {
     ])
   })
 
-  it('returns empty array when no substitution', async () => {
-    const eq = vi.fn().mockResolvedValue({ data: [], error: null })
-    const select = vi.fn(() => ({ eq }))
-    ;(supabase.from as Mock).mockReturnValue({ select })
-    await expect(validateExternalHire('1')).resolves.toEqual([])
-  })
-})
+    it('returns empty array when no substitution', async () => {
+      const eq = vi.fn().mockResolvedValue({ data: [], error: null })
+      const select = vi.fn(() => ({ eq }))
+      ;(supabase.from as Mock).mockReturnValue({ select })
+      await expect(validateExternalHire('1')).resolves.toEqual([])
+    })
 
-describe('validateOperatorAssignment', () => {
+    it('throws when query fails', async () => {
+      const eq = vi.fn().mockResolvedValue({ data: null, error: { message: 'boom' } })
+      const select = vi.fn(() => ({ eq }))
+      ;(supabase.from as Mock).mockReturnValue({ select })
+      await expect(validateExternalHire('1')).rejects.toThrow('boom')
+    })
+  })
+
+  describe('validateOperatorAssignment', () => {
   beforeEach(() => {
     ;(supabase.from as Mock).mockReset()
   })
@@ -66,9 +73,9 @@ describe('validateOperatorAssignment', () => {
     )
   })
 
-  it('passes when operator has required tickets', async () => {
-    const from = supabase.from as Mock
-    from.mockImplementation((table: string) => {
+    it('passes when operator has required tickets', async () => {
+      const from = supabase.from as Mock
+      from.mockImplementation((table: string) => {
       if (table === 'group_required_tickets') {
         const eq = vi.fn().mockResolvedValue({
           data: [
@@ -92,6 +99,44 @@ describe('validateOperatorAssignment', () => {
       return { select: () => ({ eq: vi.fn() }) }
     })
 
-    await expect(validateOperatorAssignment('1', 'op')).resolves.toBeUndefined()
+      await expect(validateOperatorAssignment('1', 'op')).resolves.toBeUndefined()
+    })
+
+    it('returns early when group has no required tickets', async () => {
+      const from = supabase.from as Mock
+      from.mockImplementation((table: string) => {
+        if (table === 'group_required_tickets') {
+          const eq = vi.fn().mockResolvedValue({ data: [], error: null })
+          return { select: () => ({ eq }) }
+        }
+        if (table === 'operator_tickets') {
+          const eq = vi.fn().mockResolvedValue({ data: [], error: null })
+          return { select: () => ({ eq }) }
+        }
+        return { select: () => ({ eq: vi.fn() }) }
+      })
+
+      await expect(validateOperatorAssignment('1', 'op')).resolves.toBeUndefined()
+      expect(from).toHaveBeenCalledTimes(1)
+    })
+
+    it('throws when operator ticket query fails', async () => {
+      const from = supabase.from as Mock
+      from.mockImplementation((table: string) => {
+        if (table === 'group_required_tickets') {
+          const eq = vi.fn().mockResolvedValue({
+            data: [{ group_id: '1', ticket_code: 'A' }],
+            error: null,
+          })
+          return { select: () => ({ eq }) }
+        }
+        if (table === 'operator_tickets') {
+          const eq = vi.fn().mockResolvedValue({ data: null, error: { message: 'oops' } })
+          return { select: () => ({ eq }) }
+        }
+        return { select: () => ({ eq: vi.fn() }) }
+      })
+
+      await expect(validateOperatorAssignment('1', 'op')).rejects.toThrow('oops')
+    })
   })
-})


### PR DESCRIPTION
## Summary
- cover more React Query hooks including events, groups, allocations, requests and scheduling
- test validation edge cases and early return paths
- exercise ProtectedRoute loading state and multi-role access
- add CalendarPage integration tests for off-hire and reassign flows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a4a227b8e8832cbce99fecb49d39ef