### PR TITLE
feat: tighten access checks and policy coverage

### DIFF
--- a/FleetFlow/src/App.tsx
+++ b/FleetFlow/src/App.tsx
@@ -5,6 +5,7 @@ import WorkforceCoordinatorPage from './pages/WorkforceCoordinatorPage'
 import LoginPage from './pages/LoginPage'
 import ProtectedRoute from './components/ProtectedRoute'
 import { AuthProvider } from './components/AuthProvider'
+import UnauthorizedPage from './pages/UnauthorizedPage'
 
 export default function App() {
   return (
@@ -12,6 +13,7 @@ export default function App() {
       <BrowserRouter>
         <Routes>
           <Route path='/login' element={<LoginPage />} />
+          <Route path='/unauthorized' element={<UnauthorizedPage />} />
           <Route
             path='/'
             element={

--- a/FleetFlow/src/components/ProtectedRoute.test.tsx
+++ b/FleetFlow/src/components/ProtectedRoute.test.tsx
@@ -52,14 +52,14 @@ describe('ProtectedRoute', () => {
     expect(screen.getByText('Secret')).toBeTruthy()
   })
 
-  it('redirects to home when role does not match', () => {
+  it('redirects to unauthorized when role does not match', () => {
     render(
       <AuthContext.Provider
         value={{ user: {} as User, role: 'driver', loading: false }}
       >
         <MemoryRouter initialEntries={['/protected']}>
           <Routes>
-            <Route path='/' element={<div>Home</div>} />
+            <Route path='/unauthorized' element={<div>Unauthorized</div>} />
             <Route
               path='/protected'
               element={
@@ -73,7 +73,7 @@ describe('ProtectedRoute', () => {
       </AuthContext.Provider>
     )
 
-    expect(screen.getByText('Home')).toBeTruthy()
+    expect(screen.getByText('Unauthorized')).toBeTruthy()
   })
 })
 

--- a/FleetFlow/src/components/ProtectedRoute.tsx
+++ b/FleetFlow/src/components/ProtectedRoute.tsx
@@ -20,7 +20,7 @@ export default function ProtectedRoute({
   }
 
   if (roles && roles.length > 0 && (!role || !roles.includes(role))) {
-    return <Navigate to='/' replace />
+    return <Navigate to='/unauthorized' replace />
   }
 
   return <>{children}</>

--- a/FleetFlow/src/pages/UnauthorizedPage.tsx
+++ b/FleetFlow/src/pages/UnauthorizedPage.tsx
@@ -1,0 +1,3 @@
+export default function UnauthorizedPage() {
+  return <div>You are not authorized to view this page.</div>
+}

--- a/FleetFlow/src/supabase/policies.test.ts
+++ b/FleetFlow/src/supabase/policies.test.ts
@@ -25,4 +25,25 @@ describe('RLS policies', () => {
       "auth.jwt() ->> 'role' in ('workforce_coordinator', 'admin')",
     )
   })
+
+  it('restricts hire_requests to coordinators', () => {
+    expect(sql).toContain("alter table hire_requests enable row level security")
+    expect(sql).toMatch(
+      /auth\.jwt\(\) ->> 'role' in \(\s*'plant_coordinator',\s*'workforce_coordinator',\s*'admin'\s*\)/,
+    )
+  })
+
+  it('restricts calendar_events to coordinators', () => {
+    expect(sql).toContain("alter table calendar_events enable row level security")
+    expect(sql).toMatch(
+      /auth\.jwt\(\) ->> 'role' in \(\s*'plant_coordinator',\s*'workforce_coordinator',\s*'admin'\s*\)/,
+    )
+  })
+
+  it('restricts equipment_groups to coordinators', () => {
+    expect(sql).toContain("alter table equipment_groups enable row level security")
+    expect(sql).toMatch(
+      /auth\.jwt\(\) ->> 'role' in \(\s*'plant_coordinator',\s*'workforce_coordinator',\s*'admin'\s*\)/,
+    )
+  })
 })


### PR DESCRIPTION
## Summary
- redirect unauthorized roles to dedicated page
- add unauthorized page and route
- expand RLS policy tests for coordinator read tables

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a4a1f7e700832ca5c7d3db8d5fcd2f