### PR TITLE
Restrict Supabase policies to coordinator roles

### DIFF
--- a/FleetFlow/src/components/ProtectedRoute.tsx
+++ b/FleetFlow/src/components/ProtectedRoute.tsx
@@ -19,6 +19,10 @@ export default function ProtectedRoute({
     return <Navigate to='/login' replace />
   }
 
+  if (role === 'admin') {
+    return <>{children}</>
+  }
+
   if (roles && roles.length > 0 && (!role || !roles.includes(role))) {
     return <Navigate to='/unauthorized' replace />
   }

--- a/FleetFlow/src/supabase/policies.test.ts
+++ b/FleetFlow/src/supabase/policies.test.ts
@@ -8,42 +8,46 @@ describe('RLS policies', () => {
   it('restricts external_hires to plant coordinators', () => {
     expect(sql).toContain("alter table external_hires enable row level security")
     expect(sql).toContain(
-      "auth.jwt() ->> 'role' in ('plant_coordinator', 'admin')",
+      "auth.jwt() ->> 'role' = 'plant_coordinator'",
     )
   })
 
   it('restricts allocations to plant coordinators', () => {
     expect(sql).toContain("alter table allocations enable row level security")
     expect(sql).toContain(
-      "auth.jwt() ->> 'role' in ('plant_coordinator', 'admin')",
+      "auth.jwt() ->> 'role' = 'plant_coordinator'",
     )
   })
 
   it('restricts operator_assignments to workforce coordinators', () => {
     expect(sql).toContain("alter table operator_assignments enable row level security")
     expect(sql).toContain(
-      "auth.jwt() ->> 'role' in ('workforce_coordinator', 'admin')",
+      "auth.jwt() ->> 'role' = 'workforce_coordinator'",
     )
   })
 
   it('restricts hire_requests to coordinators', () => {
     expect(sql).toContain("alter table hire_requests enable row level security")
     expect(sql).toMatch(
-      /auth\.jwt\(\) ->> 'role' in \(\s*'plant_coordinator',\s*'workforce_coordinator',\s*'admin'\s*\)/,
+      /auth\.jwt\(\) ->> 'role' in \(\s*'plant_coordinator',\s*'workforce_coordinator'\s*\)/,
     )
   })
 
   it('restricts calendar_events to coordinators', () => {
     expect(sql).toContain("alter table calendar_events enable row level security")
     expect(sql).toMatch(
-      /auth\.jwt\(\) ->> 'role' in \(\s*'plant_coordinator',\s*'workforce_coordinator',\s*'admin'\s*\)/,
+      /auth\.jwt\(\) ->> 'role' in \(\s*'plant_coordinator',\s*'workforce_coordinator'\s*\)/,
     )
   })
 
   it('restricts equipment_groups to coordinators', () => {
     expect(sql).toContain("alter table equipment_groups enable row level security")
     expect(sql).toMatch(
-      /auth\.jwt\(\) ->> 'role' in \(\s*'plant_coordinator',\s*'workforce_coordinator',\s*'admin'\s*\)/,
+      /auth\.jwt\(\) ->> 'role' in \(\s*'plant_coordinator',\s*'workforce_coordinator'\s*\)/,
     )
+  })
+
+  it('does not expose admin role in policies', () => {
+    expect(sql).not.toContain("'admin'")
   })
 })

--- a/FleetFlow/supabase/policies.sql
+++ b/FleetFlow/supabase/policies.sql
@@ -7,23 +7,23 @@ revoke select on external_hires from public;
 create policy external_hires_select_plant on external_hires
 for select
 to authenticated
-using (auth.jwt() ->> 'role' in ('plant_coordinator', 'admin'));
+using (auth.jwt() ->> 'role' = 'plant_coordinator');
 
 create policy external_hires_insert_plant on external_hires
 for insert
 to authenticated
-with check (auth.jwt() ->> 'role' in ('plant_coordinator', 'admin'));
+with check (auth.jwt() ->> 'role' = 'plant_coordinator');
 
 create policy external_hires_update_plant on external_hires
 for update
 to authenticated
-using (auth.jwt() ->> 'role' in ('plant_coordinator', 'admin'))
-with check (auth.jwt() ->> 'role' in ('plant_coordinator', 'admin'));
+using (auth.jwt() ->> 'role' = 'plant_coordinator')
+with check (auth.jwt() ->> 'role' = 'plant_coordinator');
 
 create policy external_hires_delete_plant on external_hires
 for delete
 to authenticated
-using (auth.jwt() ->> 'role' in ('plant_coordinator', 'admin'));
+using (auth.jwt() ->> 'role' = 'plant_coordinator');
 
 -- allocations: only plant coordinators may modify
 alter table allocations enable row level security;
@@ -32,23 +32,23 @@ revoke select on allocations from public;
 create policy allocations_select_plant on allocations
 for select
 to authenticated
-using (auth.jwt() ->> 'role' in ('plant_coordinator', 'admin'));
+using (auth.jwt() ->> 'role' = 'plant_coordinator');
 
 create policy allocations_insert_plant on allocations
 for insert
 to authenticated
-with check (auth.jwt() ->> 'role' in ('plant_coordinator', 'admin'));
+with check (auth.jwt() ->> 'role' = 'plant_coordinator');
 
 create policy allocations_update_plant on allocations
 for update
 to authenticated
-using (auth.jwt() ->> 'role' in ('plant_coordinator', 'admin'))
-with check (auth.jwt() ->> 'role' in ('plant_coordinator', 'admin'));
+using (auth.jwt() ->> 'role' = 'plant_coordinator')
+with check (auth.jwt() ->> 'role' = 'plant_coordinator');
 
 create policy allocations_delete_plant on allocations
 for delete
 to authenticated
-using (auth.jwt() ->> 'role' in ('plant_coordinator', 'admin'));
+using (auth.jwt() ->> 'role' = 'plant_coordinator');
 
 -- operator_assignments: only workforce coordinators may modify
 alter table operator_assignments enable row level security;
@@ -57,27 +57,27 @@ revoke select on operator_assignments from public;
 create policy operator_assignments_select_workforce on operator_assignments
 for select
 to authenticated
-using (auth.jwt() ->> 'role' in ('workforce_coordinator', 'admin'));
+using (auth.jwt() ->> 'role' = 'workforce_coordinator');
 
 create policy operator_assignments_insert_workforce on operator_assignments
 for insert
 to authenticated
 with check (
-  auth.jwt() ->> 'role' in ('workforce_coordinator', 'admin')
+  auth.jwt() ->> 'role' = 'workforce_coordinator'
 );
 
 create policy operator_assignments_update_workforce on operator_assignments
 for update
 to authenticated
-using (auth.jwt() ->> 'role' in ('workforce_coordinator', 'admin'))
+using (auth.jwt() ->> 'role' = 'workforce_coordinator')
 with check (
-  auth.jwt() ->> 'role' in ('workforce_coordinator', 'admin')
+  auth.jwt() ->> 'role' = 'workforce_coordinator'
 );
 
 create policy operator_assignments_delete_workforce on operator_assignments
 for delete
 to authenticated
-using (auth.jwt() ->> 'role' in ('workforce_coordinator', 'admin'));
+using (auth.jwt() ->> 'role' = 'workforce_coordinator');
 
 -- hire_requests: coordinators may read
 alter table hire_requests enable row level security;
@@ -89,8 +89,7 @@ to authenticated
 using (
   auth.jwt() ->> 'role' in (
     'plant_coordinator',
-    'workforce_coordinator',
-    'admin'
+    'workforce_coordinator'
   )
 );
 
@@ -104,8 +103,7 @@ to authenticated
 using (
   auth.jwt() ->> 'role' in (
     'plant_coordinator',
-    'workforce_coordinator',
-    'admin'
+    'workforce_coordinator'
   )
 );
 
@@ -119,8 +117,7 @@ to authenticated
 using (
   auth.jwt() ->> 'role' in (
     'plant_coordinator',
-    'workforce_coordinator',
-    'admin'
+    'workforce_coordinator'
   )
 );
 


### PR DESCRIPTION
## Summary
- tighten Supabase RLS policies to coordinator roles only
- allow admin bypass in ProtectedRoute
- update policy tests for new restrictions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a4bb3c88a8832c92ec0d3003ce3855