### PR TITLE
Add Playwright test harness for allocation workflows

### DIFF
--- a/FleetFlow/package.json
+++ b/FleetFlow/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",
+    "test:e2e": "playwright test -c playwright-ct.config.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -23,6 +24,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
+    "@playwright/experimental-ct-react": "^1.49.1",
+    "@playwright/test": "^1.49.1",
     "@testing-library/react": "^16.0.0",
     "jsdom": "^24.0.0",
     "@types/react": "^19.1.10",

--- a/FleetFlow/playwright-ct.config.ts
+++ b/FleetFlow/playwright-ct.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from '@playwright/experimental-ct-react'
+
+export default defineConfig({
+  testDir: './src/pages/__tests__',
+  testMatch: /.*\.pwtest\.tsx/,
+  snapshotDir: './src/pages/__tests__/__snapshots__',
+  use: {
+    viewport: { width: 1280, height: 720 },
+  },
+  ctViteConfig: {
+    define: {
+      'import.meta.env.VITE_SUPABASE_URL': JSON.stringify(process.env.VITE_SUPABASE_URL),
+      'import.meta.env.VITE_SUPABASE_ANON_KEY': JSON.stringify(process.env.VITE_SUPABASE_ANON_KEY),
+    },
+  },
+})

--- a/FleetFlow/src/pages/__tests__/allocation-flow.pwtest.tsx
+++ b/FleetFlow/src/pages/__tests__/allocation-flow.pwtest.tsx
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/experimental-ct-react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactElement } from 'react'
+import PlantCoordinatorPage from '../PlantCoordinatorPage'
+import WorkforceCoordinatorPage from '../WorkforceCoordinatorPage'
+import { supabase } from '../../lib/supabase'
+
+const withProviders = (component: ReactElement) => {
+  const queryClient = new QueryClient()
+  return (
+    <QueryClientProvider client={queryClient}>{component}</QueryClientProvider>
+  )
+}
+
+test('allocates asset via PlantCoordinatorPage', async ({ mount }) => {
+  const component = await mount(withProviders(<PlantCoordinatorPage />))
+  const { count: before } = await supabase
+    .from('vw_allocations')
+    .select('*', { count: 'exact', head: true })
+  await component.getByRole('button', { name: 'Allocate Assets' }).click()
+  await component.getByText(/allocated/)
+  const { count: after } = await supabase
+    .from('vw_allocations')
+    .select('*', { count: 'exact', head: true })
+  expect((after ?? 0) > (before ?? 0)).toBeTruthy()
+})
+
+test('assigns operator via WorkforceCoordinatorPage', async ({ mount }) => {
+  const component = await mount(withProviders(<WorkforceCoordinatorPage />))
+  const { count: before } = await supabase
+    .from('operator_assignments')
+    .select('*', { count: 'exact', head: true })
+  await component.getByRole('button', { name: 'Rank Operators' }).click()
+  await component.getByRole('button', { name: /Assign/ }).click()
+  await component.getByText('Operator assigned!')
+  const { count: after } = await supabase
+    .from('operator_assignments')
+    .select('*', { count: 'exact', head: true })
+  expect((after ?? 0) > (before ?? 0)).toBeTruthy()
+})


### PR DESCRIPTION
## Summary
- setup Playwright component test runner and npm script
- add component tests for allocation and operator assignment verifying Supabase effects

## Testing
- `npm run lint`
- `npm test`
- `npm run test:e2e` *(fails: SyntaxError: Identifier 'QueryClientProvider' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_b_68a4bb4e2174832c9e2969764feecc2b