### PR TITLE
Improve async error handling with friendly messages

### DIFF
--- a/FleetFlow/src/components/EventDetailsDrawer.tsx
+++ b/FleetFlow/src/components/EventDetailsDrawer.tsx
@@ -1,5 +1,7 @@
 import * as Dialog from '@radix-ui/react-dialog'
+import { useState } from 'react'
 import type { CalendarEvent } from '../types'
+import { friendlyErrorMessage } from '../utils/errors'
 import './week-calendar.css'
 
 export interface EventDetailsDrawerProps {
@@ -17,6 +19,31 @@ export default function EventDetailsDrawer({
   onOffHire,
   onReassign,
 }: EventDetailsDrawerProps) {
+  const [error, setError] = useState<string | null>(null)
+
+  const handleOffHire = async () => {
+    if (!event || !onOffHire) return
+    try {
+      setError(null)
+      await onOffHire(event)
+    } catch (err) {
+      const message =
+        err instanceof Error ? friendlyErrorMessage(err.message) : String(err)
+      setError(message)
+    }
+  }
+
+  const handleReassign = async () => {
+    if (!event || !onReassign) return
+    try {
+      setError(null)
+      await onReassign(event)
+    } catch (err) {
+      const message =
+        err instanceof Error ? friendlyErrorMessage(err.message) : String(err)
+      setError(message)
+    }
+  }
   return (
     <Dialog.Root open={open} onOpenChange={(o) => !o && onClose()}>
       <Dialog.Portal>
@@ -35,13 +62,10 @@ export default function EventDetailsDrawer({
             </div>
           )}
           <div className='drawer-actions'>
-            <button onClick={() => event && onOffHire?.(event)}>
-              Off-hire
-            </button>
-            <button onClick={() => event && onReassign?.(event)}>
-              Reassign
-            </button>
+            <button onClick={handleOffHire}>Off-hire</button>
+            <button onClick={handleReassign}>Reassign</button>
           </div>
+          {error && <div role='alert'>{error}</div>}
           <Dialog.Close className='drawer-close'>Close</Dialog.Close>
         </Dialog.Content>
       </Dialog.Portal>

--- a/FleetFlow/src/utils/errors.test.ts
+++ b/FleetFlow/src/utils/errors.test.ts
@@ -6,6 +6,9 @@ describe('friendlyErrorMessage', () => {
     expect(friendlyErrorMessage('ALLOCATION_OVERLAP')).toBe(
       'Allocation overlaps with existing allocation',
     )
+    expect(friendlyErrorMessage('UNAUTHORIZED')).toBe(
+      'You are not authorized to perform this action',
+    )
   })
 
   it('returns original code when unknown', () => {

--- a/FleetFlow/src/utils/errors.ts
+++ b/FleetFlow/src/utils/errors.ts
@@ -8,6 +8,12 @@ export function friendlyErrorMessage(code: string): string {
       return 'No internal asset available';
     case 'MISSING_REQUIRED_TICKETS':
       return 'Operator is missing required tickets';
+    case 'INVALID_DATE_RANGE':
+      return 'Start date must be before end date';
+    case 'REQUEST_NOT_FOUND':
+      return 'Request not found';
+    case 'UNAUTHORIZED':
+      return 'You are not authorized to perform this action';
     default:
       return code;
   }


### PR DESCRIPTION
## Summary
- expand error helper with messages for invalid date range, request not found, and unauthorized codes
- wrap async actions in pages and drawers with try/catch and show alert messages
- surface errors consistently via `friendlyErrorMessage`

## Testing
- `pre-commit run --files FleetFlow/src/components/EventDetailsDrawer.tsx FleetFlow/src/pages/PlantCoordinatorPage.tsx FleetFlow/src/pages/WorkforceCoordinatorPage.tsx FleetFlow/src/utils/errors.test.ts FleetFlow/src/utils/errors.ts`
- `npm --prefix FleetFlow test`
- `npm --prefix FleetFlow run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68a4bef6d9e8832c9f60500a6c39e232