### PR TITLE
feat: support admin role

### DIFF
--- a/FleetFlow/README.md
+++ b/FleetFlow/README.md
@@ -1,6 +1,6 @@
 # FleetFlow
 
-FleetFlow is a role‑based civil engineering **fleet & operated plant scheduler**. It maximises **owned equipment** use before **external hires**, using a **financial‑weeks calendar** to show demand vs capacity by equipment group. Contract Managers create contracts/requests, Plant Coordinators allocate assets or raise external hires with substitution rules, and Workforce Coordinators assign operators based on tickets, availability, and proximity. Supabase/Postgres enforces availability and scoring.
+FleetFlow is a role‑based civil engineering **fleet & operated plant scheduler**. It maximises **owned equipment** use before **external hires**, using a **financial‑weeks calendar** to show demand vs capacity by equipment group. Contract Managers create contracts/requests, Plant Coordinators allocate assets or raise external hires with substitution rules, and Workforce Coordinators assign operators based on tickets, availability, and proximity, and Admins manage user accounts and roles. Supabase/Postgres enforces availability and scoring.
 
 ---
 
@@ -125,10 +125,14 @@ Open [http://localhost:5173](http://localhost:5173) (or the port Vite shows). Th
 
 * For operated requests, assign `operators` who have required tickets and no overlaps
 
+**Admins**
+
+* Manage user accounts and roles
+
 ## Authorization
 
 Roles live in the `profiles.role` column and are surfaced to clients through a custom JWT
-claim. The frontend's route guards use this value for a better UX, but these checks are
+claim. Valid roles are `admin`, `contract_manager`, `plant_coordinator`, and `workforce_coordinator`. The frontend's route guards use this value for a better UX, but these checks are
 advisory—Postgres **row level security** is the source of truth and enforces all
 authorization.
 

--- a/FleetFlow/src/components/ProtectedRoute.test.tsx
+++ b/FleetFlow/src/components/ProtectedRoute.test.tsx
@@ -1,10 +1,14 @@
 /** @vitest-environment jsdom */
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, afterEach } from 'vitest'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
-import { render, screen } from '@testing-library/react'
+import { render, screen, cleanup } from '@testing-library/react'
 import ProtectedRoute from './ProtectedRoute'
 import { AuthContext } from './auth-context'
 import type { User } from '@supabase/supabase-js'
+
+afterEach(() => {
+  cleanup()
+})
 
 describe('ProtectedRoute', () => {
   it('redirects to login when user is not authenticated', () => {
@@ -76,7 +80,29 @@ describe('ProtectedRoute', () => {
     expect(screen.getByText('Unauthorized')).toBeTruthy()
   })
 
-  it('renders loading state when auth is loading', () => {
+  
+    it('allows admin to access any route', () => {
+      render(
+        <AuthContext.Provider value={{ user: {} as User, role: 'admin', loading: false }}>
+          <MemoryRouter initialEntries={['/protected']}>
+            <Routes>
+              <Route
+                path='/protected'
+                element={
+                  <ProtectedRoute roles={['plant_coordinator']}>
+                    <div>Secret</div>
+                  </ProtectedRoute>
+                }
+              />
+            </Routes>
+          </MemoryRouter>
+        </AuthContext.Provider>,
+      )
+
+      expect(screen.getByText('Secret')).toBeTruthy()
+    })
+
+    it('renders loading state when auth is loading', () => {
     render(
       <AuthContext.Provider value={{ user: null, role: null, loading: true }}>
         <MemoryRouter initialEntries={['/protected']}>

--- a/FleetFlow/src/supabase/policies.test.ts
+++ b/FleetFlow/src/supabase/policies.test.ts
@@ -8,46 +8,46 @@ describe('RLS policies', () => {
   it('restricts external_hires to plant coordinators', () => {
     expect(sql).toContain("alter table external_hires enable row level security")
     expect(sql).toContain(
-      "auth.jwt() ->> 'role' = 'plant_coordinator'",
+      "auth.jwt() ->> 'role' in ('plant_coordinator','admin')",
     )
   })
 
   it('restricts allocations to plant coordinators', () => {
     expect(sql).toContain("alter table allocations enable row level security")
     expect(sql).toContain(
-      "auth.jwt() ->> 'role' = 'plant_coordinator'",
+      "auth.jwt() ->> 'role' in ('plant_coordinator','admin')",
     )
   })
 
   it('restricts operator_assignments to workforce coordinators', () => {
     expect(sql).toContain("alter table operator_assignments enable row level security")
     expect(sql).toContain(
-      "auth.jwt() ->> 'role' = 'workforce_coordinator'",
+      "auth.jwt() ->> 'role' in ('workforce_coordinator','admin')",
     )
   })
 
   it('restricts hire_requests to coordinators', () => {
     expect(sql).toContain("alter table hire_requests enable row level security")
     expect(sql).toMatch(
-      /auth\.jwt\(\) ->> 'role' in \(\s*'plant_coordinator',\s*'workforce_coordinator'\s*\)/,
+      /auth\.jwt\(\) ->> 'role' in \(\s*'plant_coordinator',\s*'workforce_coordinator',\s*'admin'\s*\)/,
     )
   })
 
   it('restricts calendar_events to coordinators', () => {
     expect(sql).toContain("alter table calendar_events enable row level security")
     expect(sql).toMatch(
-      /auth\.jwt\(\) ->> 'role' in \(\s*'plant_coordinator',\s*'workforce_coordinator'\s*\)/,
+      /auth\.jwt\(\) ->> 'role' in \(\s*'plant_coordinator',\s*'workforce_coordinator',\s*'admin'\s*\)/,
     )
   })
 
   it('restricts equipment_groups to coordinators', () => {
     expect(sql).toContain("alter table equipment_groups enable row level security")
     expect(sql).toMatch(
-      /auth\.jwt\(\) ->> 'role' in \(\s*'plant_coordinator',\s*'workforce_coordinator'\s*\)/,
+      /auth\.jwt\(\) ->> 'role' in \(\s*'plant_coordinator',\s*'workforce_coordinator',\s*'admin'\s*\)/,
     )
   })
 
-  it('does not expose admin role in policies', () => {
-    expect(sql).not.toContain("'admin'")
+  it('includes admin role in policies', () => {
+    expect(sql).toContain("'admin'")
   })
 })

--- a/FleetFlow/src/supabase/roles.test.ts
+++ b/FleetFlow/src/supabase/roles.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const sql = readFileSync(resolve(__dirname, '../../supabase/roles.sql'), 'utf8')
+
+describe('roles', () => {
+  it('includes admin in profiles role check', () => {
+    expect(sql).toContain("'admin','contract_manager','plant_coordinator','workforce_coordinator'")
+  })
+})

--- a/FleetFlow/supabase/policies.sql
+++ b/FleetFlow/supabase/policies.sql
@@ -7,23 +7,23 @@ revoke select on external_hires from public;
 create policy external_hires_select_plant on external_hires
 for select
 to authenticated
-using (auth.jwt() ->> 'role' = 'plant_coordinator');
+using (auth.jwt() ->> 'role' in ('plant_coordinator','admin'));
 
 create policy external_hires_insert_plant on external_hires
 for insert
 to authenticated
-with check (auth.jwt() ->> 'role' = 'plant_coordinator');
+with check (auth.jwt() ->> 'role' in ('plant_coordinator','admin'));
 
 create policy external_hires_update_plant on external_hires
 for update
 to authenticated
-using (auth.jwt() ->> 'role' = 'plant_coordinator')
-with check (auth.jwt() ->> 'role' = 'plant_coordinator');
+using (auth.jwt() ->> 'role' in ('plant_coordinator','admin'))
+with check (auth.jwt() ->> 'role' in ('plant_coordinator','admin'));
 
 create policy external_hires_delete_plant on external_hires
 for delete
 to authenticated
-using (auth.jwt() ->> 'role' = 'plant_coordinator');
+using (auth.jwt() ->> 'role' in ('plant_coordinator','admin'));
 
 -- allocations: only plant coordinators may modify
 alter table allocations enable row level security;
@@ -32,23 +32,23 @@ revoke select on allocations from public;
 create policy allocations_select_plant on allocations
 for select
 to authenticated
-using (auth.jwt() ->> 'role' = 'plant_coordinator');
+using (auth.jwt() ->> 'role' in ('plant_coordinator','admin'));
 
 create policy allocations_insert_plant on allocations
 for insert
 to authenticated
-with check (auth.jwt() ->> 'role' = 'plant_coordinator');
+with check (auth.jwt() ->> 'role' in ('plant_coordinator','admin'));
 
 create policy allocations_update_plant on allocations
 for update
 to authenticated
-using (auth.jwt() ->> 'role' = 'plant_coordinator')
-with check (auth.jwt() ->> 'role' = 'plant_coordinator');
+using (auth.jwt() ->> 'role' in ('plant_coordinator','admin'))
+with check (auth.jwt() ->> 'role' in ('plant_coordinator','admin'));
 
 create policy allocations_delete_plant on allocations
 for delete
 to authenticated
-using (auth.jwt() ->> 'role' = 'plant_coordinator');
+using (auth.jwt() ->> 'role' in ('plant_coordinator','admin'));
 
 -- operator_assignments: only workforce coordinators may modify
 alter table operator_assignments enable row level security;
@@ -57,27 +57,27 @@ revoke select on operator_assignments from public;
 create policy operator_assignments_select_workforce on operator_assignments
 for select
 to authenticated
-using (auth.jwt() ->> 'role' = 'workforce_coordinator');
+using (auth.jwt() ->> 'role' in ('workforce_coordinator','admin'));
 
 create policy operator_assignments_insert_workforce on operator_assignments
 for insert
 to authenticated
 with check (
-  auth.jwt() ->> 'role' = 'workforce_coordinator'
+  auth.jwt() ->> 'role' in ('workforce_coordinator','admin')
 );
 
 create policy operator_assignments_update_workforce on operator_assignments
 for update
 to authenticated
-using (auth.jwt() ->> 'role' = 'workforce_coordinator')
+using (auth.jwt() ->> 'role' in ('workforce_coordinator','admin'))
 with check (
-  auth.jwt() ->> 'role' = 'workforce_coordinator'
+  auth.jwt() ->> 'role' in ('workforce_coordinator','admin')
 );
 
 create policy operator_assignments_delete_workforce on operator_assignments
 for delete
 to authenticated
-using (auth.jwt() ->> 'role' = 'workforce_coordinator');
+using (auth.jwt() ->> 'role' in ('workforce_coordinator','admin'));
 
 -- hire_requests: coordinators may read
 alter table hire_requests enable row level security;
@@ -89,7 +89,8 @@ to authenticated
 using (
   auth.jwt() ->> 'role' in (
     'plant_coordinator',
-    'workforce_coordinator'
+    'workforce_coordinator',
+    'admin'
   )
 );
 
@@ -103,7 +104,8 @@ to authenticated
 using (
   auth.jwt() ->> 'role' in (
     'plant_coordinator',
-    'workforce_coordinator'
+    'workforce_coordinator',
+    'admin'
   )
 );
 
@@ -117,7 +119,8 @@ to authenticated
 using (
   auth.jwt() ->> 'role' in (
     'plant_coordinator',
-    'workforce_coordinator'
+    'workforce_coordinator',
+    'admin'
   )
 );
 

--- a/FleetFlow/supabase/roles.sql
+++ b/FleetFlow/supabase/roles.sql
@@ -3,7 +3,7 @@
 -- Add role column if it doesn't exist
 alter table profiles
   add column if not exists role text
-    check (role in ('contract_manager','plant_coordinator','workforce_coordinator'))
+    check (role in ('admin','contract_manager','plant_coordinator','workforce_coordinator'))
     default 'contract_manager';
 
 -- Expose role in JWT so policies can rely on auth.jwt()->>'role'


### PR DESCRIPTION
## Summary
- allow `admin` in profile role check constraint
- permit `admin` across row level security policies
- document and test the admin role

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a4c4acf1f0832ca391814bc96cb959