### PR TITLE
Prevent overlapping operator assignments

### DIFF
--- a/FleetFlow/src/supabase/constraints.test.ts
+++ b/FleetFlow/src/supabase/constraints.test.ts
@@ -9,4 +9,10 @@ describe('Constraints', () => {
     expect(sql).toContain('constraint allocations_no_overlap')
     expect(sql).toContain("daterange(start_date, end_date, '[]')")
   })
+
+  it('prevents overlapping operator assignments', () => {
+    expect(sql).toContain('constraint operator_assignments_no_overlap')
+    expect(sql).toContain('operator_id with =')
+    expect(sql).toContain("constraint operator_assignments_date_order")
+  })
 })

--- a/FleetFlow/supabase/constraints.sql
+++ b/FleetFlow/supabase/constraints.sql
@@ -9,3 +9,15 @@ alter table allocations
     asset_id with =,
     daterange(start_date, end_date, '[]') with &&
   );
+
+-- operator_assignments_no_overlap: prevent double-booking an operator
+alter table operator_assignments
+  add constraint operator_assignments_no_overlap
+  exclude using gist (
+    operator_id with =,
+    daterange(start_date, end_date, '[]') with &&
+  );
+
+alter table operator_assignments
+  add constraint operator_assignments_date_order
+  check (start_date <= end_date);


### PR DESCRIPTION
## Summary
- prevent overlapping operator assignments using exclusion constraint
- enforce operator assignment date ordering
- verify constraints with updated tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a4c5081648832caf9fa2f048c94274