### PR TITLE
Add stub RPCs for asset scoring and allocation

### DIFF
--- a/FleetFlow/supabase/rpc_allocate_best_asset.sql
+++ b/FleetFlow/supabase/rpc_allocate_best_asset.sql
@@ -1,0 +1,39 @@
+-- Function: rpc_allocate_best_asset
+-- Description: Tries to allocate the best eligible internal asset for a request; raises if none.
+-- Parameters:
+--   request_id uuid - hire request to allocate for
+-- Returns: uuid of the allocated asset
+create or replace function rpc_allocate_best_asset(
+  request_id uuid
+)
+returns uuid
+language plpgsql security definer set search_path=public
+as $$
+declare
+  req hire_requests%rowtype;
+  cand record;
+begin
+  select * into req from hire_requests where id = request_id;
+  if not found then
+    raise exception 'REQUEST_NOT_FOUND';
+  end if;
+
+  for cand in
+    select a.id, a.code, s.score
+      from rpc_score_assets(request_id) s
+      join assets a on a.code = s.asset_code
+     order by s.score desc nulls last
+  loop
+    begin
+      insert into allocations(asset_id, group_id, start_date, end_date, request_id)
+      values (cand.id, req.group_id, req.start_date, req.end_date, request_id);
+      return cand.id;
+    exception
+      when exclusion_violation then
+        -- try next candidate
+    end;
+  end loop;
+
+  raise exception 'NO_INTERNAL_ASSET_AVAILABLE';
+end;
+$$;

--- a/FleetFlow/supabase/rpc_score_assets.sql
+++ b/FleetFlow/supabase/rpc_score_assets.sql
@@ -1,0 +1,16 @@
+-- Function: rpc_score_assets
+-- Description: Scores internal assets for a request (distance, availability, etc.).
+-- Parameters:
+--   request_id uuid - hire request to score assets for
+-- Returns: table(asset_code text, score double precision)
+create or replace function rpc_score_assets(
+  request_id uuid
+)
+returns table(asset_code text, score double precision)
+language sql
+as $$
+  select a.code, 1.0 as score
+    from assets a
+    -- TODO: join availability, distance, maintenance, etc.
+   order by 1;
+$$;


### PR DESCRIPTION
## Summary
- add rpc_score_assets to score candidate internal assets
- add rpc_allocate_best_asset to pick the best asset for a request

## Testing
- `npm test`
- `pre-commit run --files supabase/rpc_score_assets.sql supabase/rpc_allocate_best_asset.sql`


------
https://chatgpt.com/codex/tasks/task_b_68a4c55920f4832cb406eb596af66884