### PR TITLE
Add core schema and calendar views with RLS

### DIFF
--- a/FleetFlow/src/supabase/policies.test.ts
+++ b/FleetFlow/src/supabase/policies.test.ts
@@ -40,6 +40,15 @@ describe('RLS policies', () => {
     )
   })
 
+  it('restricts vw_weekly_group_utilization to coordinators', () => {
+    expect(sql).toContain(
+      'alter view vw_weekly_group_utilization enable row level security',
+    )
+    expect(sql).toMatch(
+      /auth\.jwt\(\) ->> 'role' in \(\s*'plant_coordinator',\s*'workforce_coordinator',\s*'admin'\s*\)/,
+    )
+  })
+
   it('restricts equipment_groups to coordinators', () => {
     expect(sql).toContain("alter table equipment_groups enable row level security")
     expect(sql).toMatch(

--- a/FleetFlow/supabase/policies.sql
+++ b/FleetFlow/supabase/policies.sql
@@ -97,6 +97,7 @@ using (
 -- calendar_events: coordinators may read
 alter table calendar_events enable row level security;
 revoke select on calendar_events from public;
+grant select on calendar_events to authenticated;
 
 create policy calendar_events_select_coordinators on calendar_events
 for select
@@ -173,5 +174,19 @@ using (
     select 1 from contract_memberships cm
     where cm.contract_id = vw_operator_assignments.contract_id
     and cm.profile_id = auth.uid()
+  )
+);
+
+-- vw_weekly_group_utilization: coordinators may read
+grant select on vw_weekly_group_utilization to authenticated;
+alter view vw_weekly_group_utilization enable row level security;
+create policy vw_weekly_group_utilization_select on vw_weekly_group_utilization
+for select
+to authenticated
+using (
+  auth.jwt() ->> 'role' in (
+    'plant_coordinator',
+    'workforce_coordinator',
+    'admin'
   )
 );

--- a/FleetFlow/supabase/schema.sql
+++ b/FleetFlow/supabase/schema.sql
@@ -1,0 +1,132 @@
+-- Core tables
+
+create table equipment_groups (
+  id serial primary key,
+  name text not null unique
+);
+
+create table group_substitutions (
+  group_id int references equipment_groups(id) on delete cascade,
+  substitute_group_id int references equipment_groups(id) on delete cascade,
+  primary key (group_id, substitute_group_id)
+);
+
+create table tickets (
+  code text primary key,
+  description text
+);
+
+create table operators (
+  id serial primary key,
+  name text not null
+);
+
+create table operator_unavailability (
+  id serial primary key,
+  operator_id int not null references operators(id) on delete cascade,
+  start_date date not null,
+  end_date date not null,
+  reason text,
+  check (start_date <= end_date)
+);
+
+create table operator_tickets (
+  operator_id int not null references operators(id) on delete cascade,
+  ticket_code text not null references tickets(code) on delete cascade,
+  primary key (operator_id, ticket_code)
+);
+
+create table group_required_tickets (
+  group_id int not null references equipment_groups(id) on delete cascade,
+  ticket_code text not null references tickets(code) on delete cascade,
+  primary key (group_id, ticket_code)
+);
+
+create table contracts (
+  id serial primary key,
+  code text not null unique,
+  status text not null
+);
+
+create table hire_requests (
+  id serial primary key,
+  contract_id int references contracts(id) on delete cascade,
+  group_id int not null references equipment_groups(id),
+  start_date date not null,
+  end_date date not null,
+  quantity int not null,
+  operated boolean not null default false,
+  site_lat double precision,
+  site_lon double precision,
+  check (start_date <= end_date)
+);
+
+create table assets (
+  id serial primary key,
+  code text not null unique,
+  group_id int not null references equipment_groups(id)
+);
+
+create table allocations (
+  id serial primary key,
+  asset_id int not null references assets(id),
+  group_id int not null references equipment_groups(id),
+  contract_id int references contracts(id) on delete cascade,
+  request_id int references hire_requests(id) on delete set null,
+  start_date date not null,
+  end_date date not null,
+  check (start_date <= end_date)
+);
+
+create table operator_assignments (
+  id serial primary key,
+  operator_id int not null references operators(id),
+  contract_id int references contracts(id) on delete cascade,
+  request_id int references hire_requests(id) on delete set null,
+  start_date date not null,
+  end_date date not null,
+  check (start_date <= end_date)
+);
+
+-- Views
+
+create or replace view calendar_events as
+select
+  'allocation-' || a.id::text as id,
+  a.start_date as date,
+  'Allocation ' || asset.code as title,
+  null::text as site,
+  c.status as contract_status,
+  false as operated,
+  asset.code as asset_code,
+  null::text as operator_name
+from allocations a
+join assets asset on asset.id = a.asset_id
+left join contracts c on c.id = a.contract_id
+union all
+select
+  'request-' || r.id::text as id,
+  r.start_date as date,
+  'Request ' || eg.name as title,
+  null::text as site,
+  c.status as contract_status,
+  r.operated,
+  null::text as asset_code,
+  null::text as operator_name
+from hire_requests r
+join equipment_groups eg on eg.id = r.group_id
+left join contracts c on c.id = r.contract_id;
+
+create or replace view vw_weekly_group_utilization as
+select
+  gs.week_start::date as week_start,
+  a.group_id,
+  count(*) as on_hire_count
+from allocations a
+join generate_series(
+  date_trunc('week', a.start_date),
+  date_trunc('week', a.end_date),
+  interval '1 week'
+) as gs(week_start) on true
+group by gs.week_start, a.group_id;
+

--- a/FleetFlow/supabase/seed.sql
+++ b/FleetFlow/supabase/seed.sql
@@ -1,0 +1,34 @@
+-- Sample data for development
+
+insert into equipment_groups (name) values
+  ('18T Excavator'),
+  ('21T Excavator');
+
+insert into tickets (code, description) values
+  ('TICKET_A', 'Basic operator ticket');
+
+insert into group_substitutions (group_id, substitute_group_id) values
+  (1, 2);
+
+insert into operators (name) values
+  ('Alice'),
+  ('Bob');
+
+insert into operator_tickets (operator_id, ticket_code) values
+  (1, 'TICKET_A');
+
+insert into group_required_tickets (group_id, ticket_code) values
+  (1, 'TICKET_A');
+
+insert into contracts (code, status) values
+  ('C-001', 'confirmed');
+
+insert into assets (code, group_id) values
+  ('EX001', 1);
+
+insert into hire_requests (contract_id, group_id, start_date, end_date, quantity, operated, site_lat, site_lon) values
+  (1, 1, '2024-04-01', '2024-04-07', 1, true, 0, 0);
+
+insert into allocations (asset_id, group_id, contract_id, request_id, start_date, end_date) values
+  (1, 1, 1, 1, '2024-04-01', '2024-04-07');
+


### PR DESCRIPTION
## Summary
- define core tables and relationships in new `schema.sql`
- seed sample equipment, tickets, operators and allocations
- expose `calendar_events` and `vw_weekly_group_utilization` views with RLS policies

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a4d3b42fb8832c899abe543a474b03