### PR TITLE
Add date order checks for allocations and hires

### DIFF
--- a/FleetFlow/src/supabase/constraints.test.ts
+++ b/FleetFlow/src/supabase/constraints.test.ts
@@ -13,6 +13,11 @@ describe('Constraints', () => {
   it('prevents overlapping operator assignments', () => {
     expect(sql).toContain('constraint operator_assignments_no_overlap')
     expect(sql).toContain('operator_id with =')
-    expect(sql).toContain("constraint operator_assignments_date_order")
+  })
+
+  it('enforces start_date before end_date', () => {
+    expect(sql).toContain('constraint allocations_date_order')
+    expect(sql).toContain('constraint hire_requests_date_order')
+    expect(sql).toContain('constraint operator_assignments_date_order')
   })
 })

--- a/FleetFlow/supabase/constraints.sql
+++ b/FleetFlow/supabase/constraints.sql
@@ -10,6 +10,10 @@ alter table allocations
     daterange(start_date, end_date, '[]') with &&
   );
 
+alter table allocations
+  add constraint allocations_date_order
+  check (start_date <= end_date);
+
 -- operator_assignments_no_overlap: prevent double-booking an operator
 alter table operator_assignments
   add constraint operator_assignments_no_overlap
@@ -20,4 +24,8 @@ alter table operator_assignments
 
 alter table operator_assignments
   add constraint operator_assignments_date_order
+  check (start_date <= end_date);
+
+alter table hire_requests
+  add constraint hire_requests_date_order
   check (start_date <= end_date);

--- a/FleetFlow/supabase/rpc_off_hire_allocation.sql
+++ b/FleetFlow/supabase/rpc_off_hire_allocation.sql
@@ -10,6 +10,6 @@ returns void
 language sql
 as $$
   update allocations
-     set end_date = current_date
+     set end_date = greatest(start_date, current_date)
    where id = allocation_id;
 $$;


### PR DESCRIPTION
## Summary
- enforce `start_date <= end_date` on allocations and hire requests
- centralize date order testing across core tables
- prevent `rpc_off_hire_allocation` from inverting date ranges

## Testing
- `npm --prefix FleetFlow run lint`
- `npm --prefix FleetFlow test`

------
https://chatgpt.com/codex/tasks/task_b_68a4d701fbd0832cba58b36af2caac5b