### PR TITLE
test: verify known Monday week starts

### DIFF
--- a/FleetFlow/src/lib/weeks.test.ts
+++ b/FleetFlow/src/lib/weeks.test.ts
@@ -8,6 +8,18 @@ describe('getWeekDays', () => {
     expect(days[0].getDay()).toBe(1)
   })
 
+  it('calculates expected week starts for known dates', () => {
+    const cases: Array<[string, string]> = [
+      ['2024-01-03', '2024-01-01'],
+      ['2024-02-29', '2024-02-26'],
+      ['2024-06-23', '2024-06-17'],
+    ]
+    cases.forEach(([input, monday]) => {
+      const weekStart = getWeekDays(new Date(input))[0]
+      expect(weekStart.toISOString().slice(0, 10)).toBe(monday)
+    })
+  })
+
   it('handles fiscal week boundary around April 1', () => {
     const endOfFiscal = getWeekDays(new Date('2024-03-31'))
     expect(endOfFiscal[0].toISOString().slice(0, 10)).toBe('2024-03-25')


### PR DESCRIPTION
## Summary
- add unit test asserting week start Monday for known dates

## Testing
- `npm test --prefix FleetFlow`


------
https://chatgpt.com/codex/tasks/task_b_68a4d7416604832c83db840990db41ad