### PR TITLE
Use date-only ISO strings for operator assignments

### DIFF
--- a/FleetFlow/src/pages/WorkforceCoordinatorPage.tsx
+++ b/FleetFlow/src/pages/WorkforceCoordinatorPage.tsx
@@ -52,8 +52,8 @@ export default function WorkforceCoordinatorPage() {
       const { error } = await supabase.from('operator_assignments').insert({
         request_id: requestId,
         operator_id: operatorId,
-        start_date: startDate.toISOString(),
-        end_date: endDate.toISOString(),
+        start_date: startDate.toISOString().slice(0, 10),
+        end_date: endDate.toISOString().slice(0, 10),
       })
       if (error) {
         throw new Error(error.message)

--- a/FleetFlow/src/pages/__tests__/AllocationAndAssignment.test.tsx
+++ b/FleetFlow/src/pages/__tests__/AllocationAndAssignment.test.tsx
@@ -141,8 +141,8 @@ describe('Workforce assignment workflow', () => {
     expect(insertMock).toHaveBeenCalledWith({
       request_id: workforceRequest.id,
       operator_id: 'op1',
-      start_date: workforceRequest.start_date.toISOString(),
-      end_date: workforceRequest.end_date.toISOString(),
+      start_date: workforceRequest.start_date.toISOString().slice(0, 10),
+      end_date: workforceRequest.end_date.toISOString().slice(0, 10),
     })
   })
 })

--- a/FleetFlow/src/pages/__tests__/WorkforceCoordinatorPage.test.tsx
+++ b/FleetFlow/src/pages/__tests__/WorkforceCoordinatorPage.test.tsx
@@ -85,8 +85,8 @@ describe('WorkforceCoordinatorPage', () => {
     expect(insertMock).toHaveBeenCalledWith({
       request_id: 'req1',
       operator_id: 'op1',
-      start_date: request.start_date.toISOString(),
-      end_date: request.end_date.toISOString(),
+      start_date: request.start_date.toISOString().slice(0, 10),
+      end_date: request.end_date.toISOString().slice(0, 10),
     })
   })
 


### PR DESCRIPTION
## Summary
- Ensure operator assignment inserts send date-only ISO strings to avoid timezone boundary shifts
- Update related tests for date-only semantics

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a4d9ecf254832cab5ab5f7a19c0726