### PR TITLE
Normalize server RPC error codes

### DIFF
--- a/FleetFlow/supabase/rpc_allocate_best_asset.sql
+++ b/FleetFlow/supabase/rpc_allocate_best_asset.sql
@@ -18,6 +18,10 @@ begin
     raise exception 'REQUEST_NOT_FOUND';
   end if;
 
+  if req.start_date > req.end_date then
+    raise exception 'INVALID_DATE_RANGE';
+  end if;
+
   for cand in
     select a.id, a.code, s.score
       from rpc_score_assets(request_id) s
@@ -35,5 +39,8 @@ begin
   end loop;
 
   raise exception 'NO_INTERNAL_ASSET_AVAILABLE';
+exception
+  when insufficient_privilege then
+    raise exception 'UNAUTHORIZED';
 end;
 $$;

--- a/FleetFlow/supabase/rpc_off_hire_allocation.sql
+++ b/FleetFlow/supabase/rpc_off_hire_allocation.sql
@@ -7,9 +7,18 @@ create or replace function rpc_off_hire_allocation(
   allocation_id uuid
 )
 returns void
-language sql
+language plpgsql
 as $$
+begin
   update allocations
      set end_date = greatest(start_date, current_date)
    where id = allocation_id;
+
+  if not found then
+    raise exception 'REQUEST_NOT_FOUND';
+  end if;
+exception
+  when insufficient_privilege then
+    raise exception 'UNAUTHORIZED';
+end;
 $$;

--- a/FleetFlow/supabase/rpc_score_assets.sql
+++ b/FleetFlow/supabase/rpc_score_assets.sql
@@ -7,10 +7,16 @@ create or replace function rpc_score_assets(
   request_id uuid
 )
 returns table(asset_code text, score double precision)
-language sql
+language plpgsql
 as $$
-  select a.code, 1.0 as score
-    from assets a
-    -- TODO: join availability, distance, maintenance, etc.
-   order by 1;
+begin
+  return query
+    select a.code, 1.0 as score
+      from assets a
+      -- TODO: join availability, distance, maintenance, etc.
+     order by 1;
+exception
+  when insufficient_privilege then
+    raise exception 'UNAUTHORIZED';
+end;
 $$;

--- a/FleetFlow/supabase/rpc_validate_operator_assignment.sql
+++ b/FleetFlow/supabase/rpc_validate_operator_assignment.sql
@@ -1,0 +1,34 @@
+-- Function: rpc_validate_operator_assignment
+-- Description: Ensures an operator has all tickets required by a group.
+-- Parameters:
+--   p_group_id int - equipment group to check
+--   p_operator_id int - operator to validate
+-- Returns: void
+create or replace function rpc_validate_operator_assignment(
+  p_group_id int,
+  p_operator_id int
+)
+returns void
+language plpgsql
+as $$
+declare
+  missing_count integer;
+begin
+  select count(*) into missing_count
+  from group_required_tickets grt
+  where grt.group_id = p_group_id
+    and not exists (
+      select 1
+        from operator_tickets ot
+       where ot.operator_id = p_operator_id
+         and ot.ticket_code = grt.ticket_code
+    );
+
+  if missing_count > 0 then
+    raise exception 'MISSING_REQUIRED_TICKETS';
+  end if;
+exception
+  when insufficient_privilege then
+    raise exception 'UNAUTHORIZED';
+end;
+$$;

--- a/FleetFlow/supabase/rpc_week_starts.sql
+++ b/FleetFlow/supabase/rpc_week_starts.sql
@@ -11,11 +11,17 @@ create or replace function rpc_week_starts(
 returns table (
   week_start date
 )
-language sql
+language plpgsql
 as $$
-  select generate_series(
+begin
+  if start_date > end_date then
+    raise exception 'INVALID_DATE_RANGE';
+  end if;
+
+  return query select generate_series(
     date_trunc('week', start_date),
     date_trunc('week', end_date),
     interval '1 week'
   )::date as week_start;
+end;
 $$;


### PR DESCRIPTION
## Summary
- return INVALID_DATE_RANGE from week start and operator ranking RPCs
- surface REQUEST_NOT_FOUND and UNAUTHORIZED from allocation RPCs
- add RPC to validate operator tickets and emit MISSING_REQUIRED_TICKETS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a4da0f4b6c832c8d003928f7a73043