### PR TITLE
Tune React Query defaults for snappier UX

### DIFF
--- a/FleetFlow/src/main.tsx
+++ b/FleetFlow/src/main.tsx
@@ -5,7 +5,9 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import './index.css'
 import App from './App.tsx'
 
-const queryClient = new QueryClient()
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { staleTime: 5 * 60_000, retry: 1 } },
+})
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
## Summary
- configure QueryClient with 5-minute staleTime and single retry

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a4dd50df04832c8c1a4999cc95de7b