### PR TITLE
feat: improve operator ranking

### DIFF
--- a/FleetFlow/README.md
+++ b/FleetFlow/README.md
@@ -148,7 +148,7 @@ authorization.
 * `rpc_available_assets(group_id, start_date, end_date)`
 * `rpc_score_assets(group_id, start_date, end_date, site_lat, site_lon)` → returns ranked candidates
 * `rpc_allocate_best_asset(request_id, group_id, start_date, end_date, site_lat, site_lon)` → inserts allocation or raises `NO_INTERNAL_ASSET_AVAILABLE`
-* `rpc_rank_operators(start_date, end_date)` → lists available operators ordered by name, excluding those with overlapping assignments or unavailability
+* `rpc_rank_operators(start_date, end_date, site_lat, site_lon, weights…)` → returns available operators ordered by a weighted score of distance, future assignments, last assignment recency, and proximity to their home depot
 * `rpc_reassign_allocation(allocation_id)` → moves an allocation forward one day and errors if it overlaps
 
 ## Deployment

--- a/FleetFlow/supabase/rpc_rank_operators.sql
+++ b/FleetFlow/supabase/rpc_rank_operators.sql
@@ -1,7 +1,8 @@
 -- Function: rpc_rank_operators
--- Description: Returns available operators ranked by name, excluding those
---               with existing assignments or unavailability overlapping the
---               requested dates.
+-- Description: Returns available operators scored by distance and additional
+--               tie-breakers like future assignment load, last assignment
+--               recency, and proximity to home depot. The weights for each
+--               factor can be tuned server-side without changing clients.
 -- Parameters:
 --   req_start date - start date of the request
 --   site_lat double precision - latitude of the request site
@@ -11,7 +12,11 @@ create or replace function rpc_rank_operators(
   req_start date,
   req_end date,
   site_lat double precision,
-  site_lon double precision
+  site_lon double precision,
+  w_distance double precision default 1,
+  w_future_assign double precision default 0,
+  w_recency double precision default 0,
+  w_home_match double precision default 0
 )
 returns table (
   operator_id uuid,
@@ -29,14 +34,7 @@ begin
   return query
     select o.id as operator_id,
            o.name as operator_name,
-           case
-             when o.home_lat is not null and o.home_lon is not null then
-               (st_distanceSphere(
-                  st_makepoint(site_lon, site_lat),
-                  st_makepoint(o.home_lon, o.home_lat)
-                ) / 1000)
-             else null
-           end as distance_km
+           dist.distance_km
     from operators o
     left join operator_assignments oa
       on oa.operator_id = o.id
@@ -46,9 +44,38 @@ begin
       on ou.operator_id = o.id
      and ou.start_date <= req_end
      and ou.end_date >= req_start
+    -- precompute distance when home coords exist
+    left join lateral (
+      select (st_distanceSphere(
+                 st_makepoint(site_lon, site_lat),
+                 st_makepoint(o.home_lon, o.home_lat)
+               ) / 1000) as distance_km
+    ) dist on (o.home_lat is not null and o.home_lon is not null)
+    -- future assignments after request end
+    left join lateral (
+      select count(*) as future_count
+      from operator_assignments oa2
+      where oa2.operator_id = o.id
+        and oa2.start_date > req_end
+    ) fa on true
+    -- last assignment before request start
+    left join lateral (
+      select max(end_date) as last_end
+      from operator_assignments oa3
+      where oa3.operator_id = o.id
+        and oa3.end_date < req_start
+    ) la on true
     where oa.operator_id is null
       and ou.operator_id is null
-    order by distance_km nulls last, o.name;
+    order by
+      (coalesce(dist.distance_km, 1e6) * w_distance) +
+      (coalesce(fa.future_count, 0) * w_future_assign) +
+      (coalesce(date_part('day', current_date - la.last_end), 1e6) * w_recency) -
+      (case
+         when dist.distance_km is not null and dist.distance_km <= 50 then 1
+         else 0
+       end * w_home_match),
+      o.name;
 exception
   when insufficient_privilege then
     raise exception 'UNAUTHORIZED';


### PR DESCRIPTION
## Summary
- add weighted scoring and tie-breakers to `rpc_rank_operators`
- document updated operator ranking RPC and weight tuning

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68a4dd7a540c832c98e7f7e306c62f8f