### PR TITLE
Add allocation and operator assignment views

### DIFF
--- a/FleetFlow/src/api/queries.test.ts
+++ b/FleetFlow/src/api/queries.test.ts
@@ -151,7 +151,7 @@ describe('fetchOperatorAssignments', () => {
     })
     fromMock.mockReturnValue({ select })
     const result = await fetchOperatorAssignments()
-    expect(fromMock).toHaveBeenCalledWith('operator_assignments')
+    expect(fromMock).toHaveBeenCalledWith('vw_operator_assignments')
     expect(result).toEqual([
       {
         id: '1',

--- a/FleetFlow/src/api/queries.ts
+++ b/FleetFlow/src/api/queries.ts
@@ -185,7 +185,7 @@ export const reassignAllocation = async (
 
 export const fetchOperatorAssignments = async (): Promise<OperatorAssignment[]> => {
   const { data, error } = await supabase
-    .from('operator_assignments')
+    .from('vw_operator_assignments')
     .select('*')
   if (error) {
     throw new Error(error.message)

--- a/FleetFlow/src/pages/__tests__/allocation-flow.pwtest.tsx
+++ b/FleetFlow/src/pages/__tests__/allocation-flow.pwtest.tsx
@@ -28,13 +28,13 @@ test('allocates asset via PlantCoordinatorPage', async ({ mount }) => {
 test('assigns operator via WorkforceCoordinatorPage', async ({ mount }) => {
   const component = await mount(withProviders(<WorkforceCoordinatorPage />))
   const { count: before } = await supabase
-    .from('operator_assignments')
+    .from('vw_operator_assignments')
     .select('*', { count: 'exact', head: true })
   await component.getByRole('button', { name: 'Rank Operators' }).click()
   await component.getByRole('button', { name: /Assign/ }).click()
   await component.getByText('Operator assigned!')
   const { count: after } = await supabase
-    .from('operator_assignments')
+    .from('vw_operator_assignments')
     .select('*', { count: 'exact', head: true })
   expect((after ?? 0) > (before ?? 0)).toBeTruthy()
 })

--- a/FleetFlow/supabase/policies.sql
+++ b/FleetFlow/supabase/policies.sql
@@ -145,7 +145,20 @@ using (
 
 create or replace view vw_allocations
 with (security_barrier=true) as
-select * from allocations;
+select
+  a.id::text as id,
+  a.contract_id::text as contract_id,
+  asset.code as asset_code,
+  a.group_id::text as group_id,
+  a.start_date,
+  a.end_date,
+  'internal'::text as source,
+  c.status as contract_status,
+  c.code as contract_code,
+  a.request_id::text as request_id
+from allocations a
+join assets asset on asset.id = a.asset_id
+left join contracts c on c.id = a.contract_id;
 grant select on vw_allocations to authenticated;
 alter view vw_allocations enable row level security;
 create policy vw_allocations_select on vw_allocations
@@ -162,7 +175,14 @@ using (
 
 create or replace view vw_operator_assignments
 with (security_barrier=true) as
-select * from operator_assignments;
+select
+  oa.id::text as id,
+  oa.contract_id::text as contract_id,
+  oa.request_id::text as request_id,
+  oa.operator_id::text as operator_id,
+  oa.start_date,
+  oa.end_date
+from operator_assignments oa;
 grant select on vw_operator_assignments to authenticated;
 alter view vw_operator_assignments enable row level security;
 create policy vw_operator_assignments_select on vw_operator_assignments

--- a/FleetFlow/supabase/policies.test.ts
+++ b/FleetFlow/supabase/policies.test.ts
@@ -24,9 +24,26 @@ const hasPostgresUser = spawnSync('id', ['postgres']).status === 0;
     // minimal table structure
     run('sudo', ['-u', 'postgres', 'psql', '-d', 'fleetflow_test', '-c', `
       CREATE TABLE contract_memberships(profile_id uuid, contract_id int);
+      CREATE TABLE contracts(id serial primary key, code text, status text);
+      CREATE TABLE assets(id serial primary key, code text);
       CREATE TABLE external_hires(id serial primary key, contract_id int);
-      CREATE TABLE allocations(id serial primary key, contract_id int);
-      CREATE TABLE operator_assignments(id serial primary key, contract_id int);
+      CREATE TABLE allocations(
+        id serial primary key,
+        contract_id int,
+        asset_id int,
+        group_id int,
+        start_date date,
+        end_date date,
+        request_id int
+      );
+      CREATE TABLE operator_assignments(
+        id serial primary key,
+        contract_id int,
+        request_id int,
+        operator_id int,
+        start_date date,
+        end_date date
+      );
       INSERT INTO external_hires(contract_id) VALUES (1);
     `]);
 

--- a/FleetFlow/supabase/schema.sql
+++ b/FleetFlow/supabase/schema.sql
@@ -117,6 +117,32 @@ from hire_requests r
 join equipment_groups eg on eg.id = r.group_id
 left join contracts c on c.id = r.contract_id;
 
+create or replace view vw_allocations as
+select
+  a.id::text as id,
+  a.contract_id::text as contract_id,
+  asset.code as asset_code,
+  a.group_id::text as group_id,
+  a.start_date,
+  a.end_date,
+  'internal'::text as source,
+  c.status as contract_status,
+  c.code as contract_code,
+  a.request_id::text as request_id
+from allocations a
+join assets asset on asset.id = a.asset_id
+left join contracts c on c.id = a.contract_id;
+
+create or replace view vw_operator_assignments as
+select
+  oa.id::text as id,
+  oa.contract_id::text as contract_id,
+  oa.request_id::text as request_id,
+  oa.operator_id::text as operator_id,
+  oa.start_date,
+  oa.end_date
+from operator_assignments oa;
+
 create or replace view vw_weekly_group_utilization as
 select
   gs.week_start::date as week_start,


### PR DESCRIPTION
## Summary
- expose `vw_allocations` and `vw_operator_assignments` views with user-facing columns
- secure the views with row level security policies
- query operator assignments through the new view in the client

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a4e3e3229c832c945ab2938e7b0c80