### PR TITLE
chore: restrict profiles to admins

### DIFF
--- a/FleetFlow/src/supabase/policies.test.ts
+++ b/FleetFlow/src/supabase/policies.test.ts
@@ -5,6 +5,11 @@ import { resolve } from 'path'
 const sql = readFileSync(resolve(__dirname, '../../supabase/policies.sql'), 'utf8')
 
 describe('RLS policies', () => {
+  it('restricts profiles to admins', () => {
+    expect(sql).toContain('alter table profiles enable row level security')
+    expect(sql).toContain("auth.jwt() ->> 'role' = 'admin'")
+  })
+
   it('restricts external_hires to plant coordinators', () => {
     expect(sql).toContain("alter table external_hires enable row level security")
     expect(sql).toContain(

--- a/FleetFlow/supabase/policies.sql
+++ b/FleetFlow/supabase/policies.sql
@@ -1,3 +1,13 @@
+-- profiles: only admins may access
+alter table profiles enable row level security;
+revoke all on profiles from public;
+
+create policy profiles_admin_all on profiles
+for all
+to authenticated
+using (auth.jwt() ->> 'role' = 'admin')
+with check (auth.jwt() ->> 'role' = 'admin');
+
 -- Row level security policies for coordinator tables
 
 -- external_hires: only plant coordinators may modify


### PR DESCRIPTION
## Summary
- enable row level security for profiles
- restrict profile access to admin users only
- add test coverage for profiles policy

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a4e50c926c832cb869efc484e40fd2