### PR TITLE
feat: soft delete profiles

### DIFF
--- a/FleetFlow/src/pages/AdminPage.tsx
+++ b/FleetFlow/src/pages/AdminPage.tsx
@@ -19,7 +19,10 @@ export default function AdminPage() {
 
   const fetchProfiles = async () => {
     setLoading(true)
-    const { data, error } = await supabase.from('profiles').select('id, email, role')
+    const { data, error } = await supabase
+      .from('profiles')
+      .select('id, email, role')
+      .eq('is_active', true)
     if (error) {
       setError(error.message)
       setProfiles([])
@@ -88,7 +91,10 @@ export default function AdminPage() {
     if (!window.confirm('Delete this user?')) {
       return
     }
-    const { error } = await supabase.from('profiles').delete().eq('id', id)
+    const { error } = await supabase
+      .from('profiles')
+      .update({ is_active: false })
+      .eq('id', id)
     if (error) {
       setError(error.message)
     } else {

--- a/FleetFlow/src/supabase/roles.test.ts
+++ b/FleetFlow/src/supabase/roles.test.ts
@@ -8,4 +8,10 @@ describe('roles', () => {
   it('includes admin in profiles role check', () => {
     expect(sql).toContain("'admin','contract_manager','plant_coordinator','workforce_coordinator'")
   })
+
+  it('adds is_active column for soft deletes', () => {
+    expect(sql).toContain(
+      'add column if not exists is_active boolean default true',
+    )
+  })
 })

--- a/FleetFlow/supabase/roles.sql
+++ b/FleetFlow/supabase/roles.sql
@@ -1,5 +1,9 @@
 -- Roles stored in profiles and surfaced via JWT + RPC
 
+-- Add soft-delete column to profiles
+alter table profiles
+  add column if not exists is_active boolean default true;
+
 -- Add role column if it doesn't exist
 alter table profiles
   add column if not exists role text


### PR DESCRIPTION
## Summary
- add is_active flag on profiles for soft deletion
- filter profiles by is_active and update deactivations in admin view
- test roles SQL for soft delete column

## Testing
- `pre-commit run --files FleetFlow/src/pages/AdminPage.tsx FleetFlow/src/supabase/roles.test.ts FleetFlow/supabase/roles.sql`
- `npm --prefix FleetFlow test`

------
https://chatgpt.com/codex/tasks/task_b_68a4ee1f99b0832c9b493aeb263e7a8b