### PR TITLE
Add E2E test job to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,30 @@ jobs:
       - name: Build
         run: npm run build
         working-directory: FleetFlow
+
+  e2e:
+    runs-on: ubuntu-latest
+    # TODO: Enable this job once a seeded ephemeral database is available
+    if: ${{ false }}
+    env:
+      VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+      DATABASE_URL: ${{ secrets.E2E_DATABASE_URL }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install
+        working-directory: FleetFlow
+
+      # Placeholder for provisioning a seeded ephemeral database
+      - name: Provision database
+        run: echo "Ephemeral database setup placeholder"
+
+      - name: Run end-to-end tests
+        run: npm run test:e2e
+        working-directory: FleetFlow


### PR DESCRIPTION
## Summary
- add placeholder e2e job to CI that runs `npm run test:e2e`
- guard E2E job behind conditional until seeded database is available
- keep E2E job independent from existing unit test job

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a4f5111354832cb7a9ffd611ed861a