### PR TITLE
refactor: define date order checks in schema

### DIFF
--- a/FleetFlow/src/supabase/constraints.test.ts
+++ b/FleetFlow/src/supabase/constraints.test.ts
@@ -2,22 +2,38 @@ import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'fs'
 import { resolve } from 'path'
 
-const sql = readFileSync(resolve(__dirname, '../../supabase/constraints.sql'), 'utf8')
+const constraintsSql = readFileSync(
+  resolve(__dirname, '../../supabase/constraints.sql'),
+  'utf8'
+)
+const schemaSql = readFileSync(
+  resolve(__dirname, '../../supabase/schema.sql'),
+  'utf8'
+)
 
 describe('Constraints', () => {
   it('prevents overlapping allocations', () => {
-    expect(sql).toContain('constraint allocations_no_overlap')
-    expect(sql).toContain("daterange(start_date, end_date, '[]')")
+    expect(constraintsSql).toContain('constraint allocations_no_overlap')
+    expect(constraintsSql).toContain("daterange(start_date, end_date, '[]')")
   })
 
   it('prevents overlapping operator assignments', () => {
-    expect(sql).toContain('constraint operator_assignments_no_overlap')
-    expect(sql).toContain('operator_id with =')
+    expect(constraintsSql).toContain('constraint operator_assignments_no_overlap')
+    expect(constraintsSql).toContain('operator_id with =')
   })
 
   it('enforces start_date before end_date', () => {
-    expect(sql).toContain('constraint allocations_date_order')
-    expect(sql).toContain('constraint hire_requests_date_order')
-    expect(sql).toContain('constraint operator_assignments_date_order')
+    expect(schemaSql).toMatch(
+      /create table operator_unavailability[\s\S]*?check \(start_date <= end_date\)/
+    )
+    expect(schemaSql).toMatch(
+      /create table hire_requests[\s\S]*?check \(start_date <= end_date\)/
+    )
+    expect(schemaSql).toMatch(
+      /create table allocations[\s\S]*?check \(start_date <= end_date\)/
+    )
+    expect(schemaSql).toMatch(
+      /create table operator_assignments[\s\S]*?check \(start_date <= end_date\)/
+    )
   })
 })

--- a/FleetFlow/supabase/constraints.sql
+++ b/FleetFlow/supabase/constraints.sql
@@ -1,4 +1,6 @@
 -- Constraints for preventing overlaps
+-- Date order checks (start_date <= end_date) are defined in table definitions
+-- (schema.sql) to avoid duplication.
 
 -- allocations_no_overlap: prevent double-booking an asset
 create extension if not exists btree_gist;
@@ -10,10 +12,6 @@ alter table allocations
     daterange(start_date, end_date, '[]') with &&
   );
 
-alter table allocations
-  add constraint allocations_date_order
-  check (start_date <= end_date);
-
 -- operator_assignments_no_overlap: prevent double-booking an operator
 alter table operator_assignments
   add constraint operator_assignments_no_overlap
@@ -21,11 +19,3 @@ alter table operator_assignments
     operator_id with =,
     daterange(start_date, end_date, '[]') with &&
   );
-
-alter table operator_assignments
-  add constraint operator_assignments_date_order
-  check (start_date <= end_date);
-
-alter table hire_requests
-  add constraint hire_requests_date_order
-  check (start_date <= end_date);

--- a/FleetFlow/supabase/schema.sql
+++ b/FleetFlow/supabase/schema.sql
@@ -1,4 +1,7 @@
 -- Core tables
+-- Date range tables include CHECK (start_date <= end_date) directly in their
+-- definitions. Any future date range tables should follow this pattern rather
+-- than using constraints.sql.
 
 create table equipment_groups (
   id serial primary key,


### PR DESCRIPTION
## Summary
- document that date range tables own their date order checks in schema.sql
- drop duplicated date order constraints from constraints.sql
- adjust constraints test to expect date order checks in schema

## Testing
- `pre-commit run --files FleetFlow/supabase/schema.sql FleetFlow/supabase/constraints.sql`
- `npm --prefix FleetFlow test`


------
https://chatgpt.com/codex/tasks/task_b_68a4f8c5ed40832c81a716a23b0862d5