### PR TITLE
redirect to home after login via auth state

### DIFF
--- a/FleetFlow/src/pages/LoginPage.tsx
+++ b/FleetFlow/src/pages/LoginPage.tsx
@@ -1,25 +1,35 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { supabase } from '../lib/supabase'
 import { useNavigate } from 'react-router-dom'
+import { useAuth } from '../components/auth-context'
 
 export default function LoginPage() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
   const navigate = useNavigate()
+  const { user } = useAuth()
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+    setSubmitting(true)
     const { error: signInError } = await supabase.auth.signInWithPassword({
       email,
       password,
     })
     if (signInError) {
       setError(signInError.message)
+      setSubmitting(false)
       return
     }
-    navigate('/')
   }
+
+  useEffect(() => {
+    if (user) {
+      navigate('/', { replace: true })
+    }
+  }, [user, navigate])
 
   return (
     <div>
@@ -41,7 +51,10 @@ export default function LoginPage() {
             onChange={(e) => setPassword(e.target.value)}
           />
         </label>
-        <button type='submit'>Sign In</button>
+        <button type='submit' disabled={submitting}>
+          {submitting ? 'Signing In...' : 'Sign In'}
+        </button>
+        {submitting && <div>Loading...</div>}
         {error && <div>{error}</div>}
       </form>
     </div>


### PR DESCRIPTION
## Summary
- redirect to root after sign-in when auth user becomes available
- show loading indicator while awaiting redirect

## Testing
- `npm --prefix FleetFlow test`
- `pre-commit run --files FleetFlow/src/pages/LoginPage.tsx`


------
https://chatgpt.com/codex/tasks/task_b_68a584f67e34832cad9322058ffecf97