### PR TITLE
Refactor auth state handling

### DIFF
--- a/FleetFlow/src/components/AuthProvider.tsx
+++ b/FleetFlow/src/components/AuthProvider.tsx
@@ -9,19 +9,26 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    const fetchUser = async () => {
+    const fetchRole = async () => {
+      try {
+        const { data: roleRes } = await supabase.rpc('rpc_get_role')
+        setRole(roleRes ?? null)
+      } catch (error) {
+        console.warn('Could not fetch user role:', error)
+        setRole('contract_manager') // Default role fallback
+      }
+    }
+
+    const initializeUser = async () => {
       setLoading(true)
       try {
-        const { data } = await supabase.auth.getUser()
-        setUser(data.user)
-        if (data.user) {
-          try {
-            const { data: roleRes } = await supabase.rpc('rpc_get_role')
-            setRole(roleRes ?? null)
-          } catch (error) {
-            console.warn('Could not fetch user role:', error)
-            setRole('contract_manager') // Default role fallback
-          }
+        const {
+          data: { session },
+        } = await supabase.auth.getSession()
+        const currentUser = session?.user ?? null
+        setUser(currentUser)
+        if (currentUser) {
+          await fetchRole()
         } else {
           setRole(null)
         }
@@ -32,11 +39,20 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       }
       setLoading(false)
     }
-    fetchUser()
+
+    initializeUser()
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange(async () => {
-      await fetchUser()
+    } = supabase.auth.onAuthStateChange(async (_event, session) => {
+      const currentUser = session?.user ?? null
+      setUser(currentUser)
+      setLoading(true)
+      if (currentUser) {
+        await fetchRole()
+      } else {
+        setRole(null)
+      }
+      setLoading(false)
     })
     return () => {
       subscription.unsubscribe()


### PR DESCRIPTION
## Summary
- Set user directly from auth session and fetch role separately
- Load role only when a user exists and avoid redundant getUser calls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a58652f53c832ca443bd24c6470818