### PR TITLE
Handle missing user role

### DIFF
--- a/FleetFlow/src/components/AuthProvider.tsx
+++ b/FleetFlow/src/components/AuthProvider.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import type { User } from '@supabase/supabase-js'
+import { toast } from 'react-hot-toast'
 import { supabase } from '../lib/supabase'
 import { AuthContext } from './auth-context'
 
@@ -14,8 +15,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         const { data: roleRes } = await supabase.rpc('rpc_get_role')
         setRole(roleRes ?? null)
       } catch (error) {
-        console.warn('Could not fetch user role:', error)
-        setRole('contract_manager') // Default role fallback
+        console.error('Could not fetch user role:', error)
+        toast.error('Failed to fetch user role')
+        setRole(null)
       }
     }
 

--- a/FleetFlow/src/components/ProtectedRoute.test.tsx
+++ b/FleetFlow/src/components/ProtectedRoute.test.tsx
@@ -145,5 +145,29 @@ describe('ProtectedRoute', () => {
 
     expect(screen.getByText('Open')).toBeTruthy()
   })
+
+  it('redirects to unauthorized when role is null even without restrictions', () => {
+    render(
+      <AuthContext.Provider
+        value={{ user: {} as User, role: null, loading: false }}
+      >
+        <MemoryRouter initialEntries={['/protected']}>
+          <Routes>
+            <Route path='/unauthorized' element={<div>Unauthorized</div>} />
+            <Route
+              path='/protected'
+              element={
+                <ProtectedRoute>
+                  <div>Open</div>
+                </ProtectedRoute>
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      </AuthContext.Provider>,
+    )
+
+    expect(screen.getByText('Unauthorized')).toBeTruthy()
+  })
 })
 

--- a/FleetFlow/src/components/ProtectedRoute.tsx
+++ b/FleetFlow/src/components/ProtectedRoute.tsx
@@ -19,11 +19,15 @@ export default function ProtectedRoute({
     return <Navigate to='/login' replace />
   }
 
+  if (role === null) {
+    return <Navigate to='/unauthorized' replace />
+  }
+
   if (role === 'admin') {
     return <>{children}</>
   }
 
-  if (roles && roles.length > 0 && (!role || !roles.includes(role))) {
+  if (roles && roles.length > 0 && !roles.includes(role)) {
     return <Navigate to='/unauthorized' replace />
   }
 


### PR DESCRIPTION
## Summary
- remove default role fallback and log errors when role fetch fails
- treat missing roles as unauthorized in ProtectedRoute
- cover unauthorized null-role scenario with tests

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68a58826741c832c8a5fd3e08046d92c