### PR TITLE
feat: validate supabase env variables

### DIFF
--- a/FleetFlow/src/lib/supabase.ts
+++ b/FleetFlow/src/lib/supabase.ts
@@ -3,4 +3,12 @@ import { createClient } from '@supabase/supabase-js'
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
 
+if (!supabaseUrl) {
+  throw new Error('VITE_SUPABASE_URL is not defined')
+}
+
+if (!supabaseAnonKey) {
+  throw new Error('VITE_SUPABASE_ANON_KEY is not defined')
+}
+
 export const supabase = createClient(supabaseUrl, supabaseAnonKey)


### PR DESCRIPTION
## Summary
- throw if `VITE_SUPABASE_URL` or `VITE_SUPABASE_ANON_KEY` is missing before creating client

## Testing
- `npm --prefix FleetFlow run lint`
- `npm --prefix FleetFlow test`


------
https://chatgpt.com/codex/tasks/task_b_68a58aaceaa0832c8f35771533aaac84