### PR TITLE
Virtualize WeekCalendar equipment groups

### DIFF
--- a/FleetFlow/package.json
+++ b/FleetFlow/package.json
@@ -21,6 +21,7 @@
     "react-dom": "^19.1.1",
     "react-hot-toast": "^2.6.0",
     "react-router-dom": "^7.8.0",
+    "react-window": "^1.8.10",
     "zod": "^4.0.17"
   },
   "devDependencies": {

--- a/FleetFlow/src/components/WeekCalendar.test.tsx
+++ b/FleetFlow/src/components/WeekCalendar.test.tsx
@@ -2,7 +2,11 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 import WeekCalendar from './WeekCalendar'
-import type { CalendarEvent } from '../types'
+import type {
+  CalendarEvent,
+  EquipmentGroup,
+  WeeklyGroupUtilization,
+} from '../types'
 
 afterEach(() => cleanup())
 
@@ -36,6 +40,31 @@ describe('WeekCalendar', () => {
     )
     fireEvent.click(screen.getByText(/Test/))
     expect(await screen.findByText('Off-hire')).toBeTruthy()
+  })
+
+  it('virtualizes equipment group rows', () => {
+    const groups: EquipmentGroup[] = Array.from({ length: 20 }, (_, i) => ({
+      id: `${i}`,
+      name: `Group ${i}`,
+    }))
+    const utilization: WeeklyGroupUtilization[] = groups.map((g) => ({
+      group_id: g.id,
+      week_start: new Date('2024-02-12'),
+      contract_id: 'c1',
+      on_hire_count: Number(g.id),
+    }))
+    render(
+      <WeekCalendar
+        selectedDate={new Date('2024-02-14')}
+        groups={groups}
+        utilization={utilization}
+      />,
+    )
+    expect(screen.getByText('Group 0')).toBeTruthy()
+    expect(screen.queryByText('Group 19')).toBeNull()
+    // verify not all rows are rendered at once
+    const rowCount = document.querySelectorAll('.utilization-row').length
+    expect(rowCount).toBeLessThan(groups.length + 1)
   })
 })
 

--- a/FleetFlow/src/components/week-calendar.css
+++ b/FleetFlow/src/components/week-calendar.css
@@ -44,15 +44,28 @@
 
 .utilization-table {
   width: 100%;
-  border-collapse: collapse;
   margin-top: 0.5rem;
+  border: 1px solid #ccc;
 }
 
-.utilization-table th,
-.utilization-table td {
-  border: 1px solid #ccc;
+.utilization-row {
+  display: flex;
+}
+
+.utilization-row > div {
+  flex: 1;
+  border-right: 1px solid #ccc;
   padding: 0.25rem;
   text-align: center;
+}
+
+.utilization-row > div:last-child {
+  border-right: none;
+}
+
+.utilization-row.header {
+  font-weight: 600;
+  border-bottom: 1px solid #ccc;
 }
 
 .drawer-overlay {


### PR DESCRIPTION
## Summary
- virtualize WeekCalendar group utilization rows using react-window
- style virtualized rows and add react-window dependency
- test virtualization behavior in WeekCalendar

## Testing
- `pre-commit run --files FleetFlow/src/components/WeekCalendar.tsx FleetFlow/src/components/week-calendar.css FleetFlow/src/components/WeekCalendar.test.tsx FleetFlow/package.json`
- `cd FleetFlow && npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ad6058bae0832c8d93d44aba9d95d7