### PR TITLE
feat: add bypass login option for dev

### DIFF
--- a/FleetFlow/src/components/AuthProvider.tsx
+++ b/FleetFlow/src/components/AuthProvider.tsx
@@ -10,6 +10,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
+    if (localStorage.getItem('bypass-auth') === 'true') {
+      setUser({ id: 'bypass' } as User)
+      setRole('admin')
+      setLoading(false)
+      return
+    }
     const fetchRole = async () => {
       try {
         const { data: roleRes } = await supabase.rpc('rpc_get_role')

--- a/FleetFlow/src/pages/LoginPage.tsx
+++ b/FleetFlow/src/pages/LoginPage.tsx
@@ -54,6 +54,17 @@ export default function LoginPage() {
         <button type='submit' disabled={submitting}>
           {submitting ? 'Signing In...' : 'Sign In'}
         </button>
+        {import.meta.env.DEV && (
+          <button
+            type='button'
+            onClick={() => {
+              localStorage.setItem('bypass-auth', 'true')
+              navigate('/')
+            }}
+          >
+            Bypass Login (dev)
+          </button>
+        )}
         {submitting && <div>Loading...</div>}
         {error && <div>{error}</div>}
       </form>

--- a/FleetFlow/src/pages/__tests__/LoginPage.test.tsx
+++ b/FleetFlow/src/pages/__tests__/LoginPage.test.tsx
@@ -1,6 +1,12 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  cleanup,
+} from '@testing-library/react'
 import type { User } from '@supabase/supabase-js'
 import LoginPage from '../LoginPage'
 
@@ -23,6 +29,14 @@ vi.mock('../../components/auth-context', () => ({
 }))
 
 describe('LoginPage', () => {
+  beforeEach(() => {
+    cleanup()
+    navigateMock.mockClear()
+    signInMock.mockClear()
+    mockUser = null
+    localStorage.clear()
+    ;(import.meta as any).env = { ...(import.meta as any).env, DEV: true }
+  })
   it('redirects after successful sign-in', async () => {
     const { rerender } = render(<LoginPage />)
 
@@ -49,5 +63,13 @@ describe('LoginPage', () => {
     )
     expect(navigateMock).toHaveBeenCalledTimes(1)
     expect(navigateMock).not.toHaveBeenCalledWith('/login', expect.anything())
+  })
+
+  it('bypasses auth and navigates home', () => {
+    render(<LoginPage />)
+    fireEvent.click(
+      screen.getByRole('button', { name: /bypass login \(dev\)/i }),
+    )
+    expect(navigateMock).toHaveBeenCalledWith('/')
   })
 })


### PR DESCRIPTION
## Summary
- allow bypassing auth when localStorage flag is set
- add dev-only "Bypass Login" button to set flag and navigate home
- cover bypass flow with a unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68adb094d4ac832cb1170a8979a0b1d2